### PR TITLE
DOC: formatting of the similarity options

### DIFF
--- a/dirty_cat/similarity_encoder.py
+++ b/dirty_cat/similarity_encoder.py
@@ -64,8 +64,8 @@ class SimilarityEncoder(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    similarity : str {'ngram', 'levenshtein-ratio', 'jaro', or
-    'jaro-winkler'}
+    similarity : str {'ngram', 'levenshtein-ratio', 'jaro', or\
+'jaro-winkler'}
         The type of pairwise string similarity to use.
 
     ngram_range : tuple (min_n, max_n), default=(3, 3)


### PR DESCRIPTION
The first option is not formatted correctly: https://dirty-cat.github.io/stable/generated/dirty_cat.SimilarityEncoder.html#dirty_cat.SimilarityEncoder

This patch is one way to solve it (although it looks a bit ugly in the source code)