### PR TITLE
#64 Benchmark with plots + scalability example

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -123,6 +123,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
 source activate testenv
 pip install sphinx-gallery
 pip install python-Levenshtein
+pip install memory_profiler
 
 #cloning and installing from the ColumnTransformer branch
 pip install scikit-learn==0.20

--- a/dirty_cat/similarity_encoder.py
+++ b/dirty_cat/similarity_encoder.py
@@ -247,7 +247,7 @@ class SimilarityEncoder(_BaseEncoder):
                         get_kmeans_protoypes(uniques, self.n_prototypes, sample_weight=count))
                 else:
                     self.categories_.append(
-                        get_kmeans_protoypes(uniques, self.n_prototypes))
+                        get_kmeans_protoypes(Xi, self.n_prototypes))
             else:
                 if self.handle_unknown == 'error':
                     valid_mask = np.in1d(Xi, self.categories[i])

--- a/dirty_cat/test/benchmark_sprint.py
+++ b/dirty_cat/test/benchmark_sprint.py
@@ -1,0 +1,162 @@
+import warnings
+from time import time
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from sklearn import pipeline, linear_model, model_selection
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import OneHotEncoder
+
+from dirty_cat import SimilarityEncoder
+from dirty_cat.datasets import fetch_traffic_violations
+
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+data = fetch_traffic_violations()
+dfr = pd.read_csv(data['path'])
+
+transformers = [
+    ('one_hot', OneHotEncoder(sparse=False, handle_unknown='ignore'),
+     ['Alcohol',
+      'Arrest Type',
+      'Belts',
+      'Commercial License',
+      'Commercial Vehicle',
+      'Fatal',
+      'Gender',
+      'HAZMAT',
+      'Property Damage',
+      'Race',
+      'Work Zone']),
+    ('pass', 'passthrough', ['Year']),
+]
+
+
+def benchmark_most_frequent(limit=50000, hash_dim=None, n_proto=100):
+    df = dfr[:limit].copy()
+    df = df.dropna(axis=0)
+    df = df.reset_index()
+
+    y = df['Violation Type']
+
+    sim_enc = SimilarityEncoder(similarity='ngram', categories='most_frequent', n_prototypes=n_proto,
+                                hashing_dim=hash_dim)
+
+    column_trans = ColumnTransformer(
+        transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+        remainder='drop'
+    )
+
+    t0 = time()
+    X = column_trans.fit_transform(df)
+    t1 = time()
+    t_score_1 = t1 - t0
+
+    model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+    t0 = time()
+    m_score = model_selection.cross_val_score(model, X, y, cv=10)
+    t1 = time()
+    t_score_2 = t1 - t0
+    return t_score_1, m_score, t_score_2
+
+
+def benchmark_k_means(limit=50000, n_proto=100, hash_dim=None, weights=False):
+    df = dfr[:limit].copy()
+    df = df.dropna(axis=0)
+    df = df.reset_index()
+
+    y = df['Violation Type']
+
+    sim_enc = SimilarityEncoder(similarity='ngram', categories='k-means', hashing_dim=hash_dim, n_prototypes=n_proto,
+                                sample_weight=weights)
+
+    column_trans = ColumnTransformer(
+        transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+        remainder='drop'
+    )
+
+    t0 = time()
+    X = column_trans.fit_transform(df)
+    t1 = time()
+    t_score_1 = t1 - t0
+
+    model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+
+    t0 = time()
+    m_score = model_selection.cross_val_score(model, X, y, cv=10)
+    t1 = time()
+    t_score_2 = t1 - t0
+    return t_score_1, m_score, t_score_2
+
+
+def plot(bench, title=''):
+    hash_dims = ['Count', '2 ** 14', '2 ** 16', '2 ** 18', '2 ** 20']
+    scores = []
+    vectorizer = []
+    strategy = []
+
+    for i, e in enumerate(bench):
+        vectorizer.extend([hash_dims[i % 5]] * (2 * len(e[0][1])))
+        strategy.extend(['k-means'] * len(e[0][1]))
+        strategy.extend(['most-frequent'] * len(e[1][1]))
+        scores.extend(e[0][1])
+        scores.extend(e[1][1])
+
+    df = pd.DataFrame(columns=['vectorizer', 'strategy', 'score'])
+    df['vectorizer'] = vectorizer
+    df['strategy'] = strategy
+    df['score'] = scores
+
+    sns.set(style='ticks', palette='muted')
+    sns.boxplot(x='vectorizer', y='score', hue='strategy', data=df)
+    plt.ylabel("Mean score on 10 cross validations")
+    plt.xlabel('Vectorizer used')
+    plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+    plt.title(title)
+    plt.tight_layout()
+    plt.show()
+
+    vectorizer.clear()
+    scores.clear()
+    strategy.clear()
+    times = []
+
+    for i, e in enumerate(bench):
+        vectorizer.extend([hash_dims[i % 5]] * 4)
+        strategy.extend(
+            ['K-means vect', 'K-means X-val', 'MF vect', 'MF X-val'])
+        times.extend([e[0][0], e[0][2], e[1][0], e[1][2]])
+
+    df = pd.DataFrame(columns=['vectorizer', 'strategy', 'time'])
+    df['vectorizer'] = vectorizer
+    df['strategy'] = strategy
+    df['time'] = times
+
+    sns.set(style='ticks', palette='muted')
+    sns.barplot(x='vectorizer', y='time', hue='strategy', data=df)
+    plt.ylabel("Time in seconds")
+    plt.xlabel('Vectorizer used')
+    plt.legend(bbox_to_anchor=(1.05, 1), loc=2, borderaxespad=0.)
+    plt.title(title)
+    plt.tight_layout()
+    plt.show()
+
+
+def loop(proto):
+    limits = sorted([dfr['Description'].nunique(), 10000, 20000, 50000, 100000])
+    hash_dims = [None, 2 ** 14, 2 ** 16, 2 ** 18, 2 ** 20]
+    weights = [False, True]
+    bench = list()
+    for limit in limits:
+        for w in weights:
+            for h in hash_dims:
+                bench.append((benchmark_k_means(limit=limit, hash_dim=h, weights=w, n_proto=proto),
+                              benchmark_most_frequent(limit=limit, n_proto=proto, hash_dim=h)))
+            title = 'Weighted K-mean: %s, Rows: %d, Prototypes: %d' % (w.__str__(), limit, proto)
+            plot(bench, title)
+            bench.clear()
+
+
+if __name__ == '__main__':
+    loop(100)

--- a/examples/04_scalability.py
+++ b/examples/04_scalability.py
@@ -4,8 +4,25 @@ Scalability considerations for  similarity encoding
 
 """
 import warnings
+from time import time
+import functools
+import memory_profiler
 
 warnings.simplefilter(action='ignore', category=FutureWarning)
+
+def resource_used(func):
+    """ Decorator that return a function that prints its usage
+    """
+    @functools.wraps(func)
+    def wrapped_func(*args, **kwargs):
+        t0 = time()
+        mem, out = memory_profiler.memory_usage((func, args, kwargs),
+                                                max_usage=True,
+                                                retval=True)
+        print("Time: %.1is    Memory used: %iMb" % (time() - t0, mem[0]))
+        return out
+    return wrapped_func
+
 
 ################################################################################
 # Data Importing and preprocessing
@@ -24,7 +41,7 @@ import pandas as pd
 df = pd.read_csv(data['path'])
 
 # Limit to 50 000 rows, for a faster example
-df = df[:50000].copy()
+df = df[:100000].copy()
 df = df.dropna(axis=0)
 df = df.reset_index()
 ################################################################################
@@ -76,21 +93,19 @@ column_trans = ColumnTransformer(
     transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
     remainder='drop')
 
-from time import time
 
-t0 = time()
-X = column_trans.fit_transform(df)
-t1 = time()
-print('Time to vectorize: %s' % (t1 - t0))
+#t0 = time()
+#X = column_trans.fit_transform(df)
+#t1 = time()
+#print('Time to vectorize: %s' % (t1 - t0))
 ################################################################################
 # We can run a cross-validation
 from sklearn import linear_model, pipeline, model_selection
+log_ref = linear_model.LogisticRegression()
 
-model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
-t0 = time()
-print(model_selection.cross_val_score(model, X, y))
-t1 = time()
-print('Cross-validation time: %s' % (t1 - t0))
+model = pipeline.make_pipeline(column_trans, log_ref)
+print("Cross-validation score: %s" %
+      resource_used(model_selection.cross_val_score)(model, df, y))
 
 
 ################################################################################
@@ -104,14 +119,12 @@ print('Cross-validation time: %s' % (t1 - t0))
 print('\nSimilarity encoding with hashing')
 
 sim_enc = SimilarityEncoder(similarity='ngram', handle_unknown='ignore',
-                            hashing_dim=2 ** 16)
+                            hashing_dim=2 ** 8)
 
 column_trans = ColumnTransformer(
     # adding the dirty column
     transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
     remainder='drop')
-
-from time import time
 
 t0 = time()
 X = column_trans.fit_transform(df)
@@ -120,12 +133,10 @@ print('Time to vectorize: %s' % (t1 - t0))
 
 ################################################################################
 # Check now that prediction is still as good
-model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
-t0 = time()
-print(model_selection.cross_val_score(model, X, y))
-t1 = time()
-print('Cross-validation time: %s' % (t1 - t0))
 
+model = pipeline.make_pipeline(column_trans, log_ref)
+print("Cross-validation score: %s" %
+      resource_used(model_selection.cross_val_score)(model, df, y))
 
 ################################################################################
 # SimilarityEncoder with most frequent strategy
@@ -153,11 +164,9 @@ print('Time to vectorize: %s' % (t1 - t0))
 
 ################################################################################
 # Check now that prediction is still as good
-model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
-t0 = time()
-print(model_selection.cross_val_score(model, X, y))
-t1 = time()
-print('Cross-validation time: %s' % (t1 - t0))
+model = pipeline.make_pipeline(column_trans, log_ref)
+print("Cross-validation score: %s" %
+      resource_used(model_selection.cross_val_score)(model, df, y))
 
 
 ################################################################################
@@ -168,7 +177,8 @@ print('Cross-validation time: %s' % (t1 - t0))
 #
 print('\nSimilarity encoding with a most frequent strategy and hashing')
 
-sim_enc = SimilarityEncoder(similarity='ngram', categories='most_frequent', n_prototypes=100, hashing_dim=2 ** 16)
+sim_enc = SimilarityEncoder(similarity='ngram',
+categories='most_frequent', n_prototypes=100, hashing_dim=2 ** 8)
 
 column_trans = ColumnTransformer(
     # adding the dirty column
@@ -184,11 +194,9 @@ print('Time to vectorize: %s' % (t1 - t0))
 
 ################################################################################
 # Check now that prediction is still as good
-model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
-t0 = time()
-print(model_selection.cross_val_score(model, X, y))
-t1 = time()
-print('Cross-validation time: %s' % (t1 - t0))
+model = pipeline.make_pipeline(column_trans, log_ref)
+print("cross-validation score: %s" %
+      resource_used(model_selection.cross_val_score)(model, df, y))
 
 
 ################################################################################
@@ -217,12 +225,9 @@ print('Time to vectorize: %s' % (t1 - t0))
 
 ################################################################################
 # Check now that prediction is still as good
-model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
-t0 = time()
-print(model_selection.cross_val_score(model, X, y))
-t1 = time()
-print('Cross-validation time: %s' % (t1 - t0))
-
+model = pipeline.make_pipeline(column_trans, log_ref)
+print("cross-validation score: %s" %
+      resource_used(model_selection.cross_val_score)(model, df, y))
 
 ################################################################################
 # SimilarityEncoder with k-means strategy
@@ -234,7 +239,8 @@ print('Cross-validation time: %s' % (t1 - t0))
 
 print('\nSimilarity encoding with a k-means strategy and hashing')
 
-sim_enc = SimilarityEncoder(similarity='ngram', categories='k-means', n_prototypes=100, hashing_dim=2 ** 16)
+sim_enc = SimilarityEncoder(similarity='ngram', categories='k-means',
+n_prototypes=100, hashing_dim=2 ** 8)
 
 column_trans = ColumnTransformer(
     # adding the dirty column
@@ -250,8 +256,7 @@ print('Time to vectorize: %s' % (t1 - t0))
 
 ################################################################################
 # Check now that prediction is still as good
-model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
-t0 = time()
-print(model_selection.cross_val_score(model, X, y))
-t1 = time()
-print('Cross-validation time: %s' % (t1 - t0))
+model = pipeline.make_pipeline(column_trans, log_ref)
+print("cross-validation score: %s" %
+      resource_used(model_selection.cross_val_score)(model, df, y))
+

--- a/examples/04_scalability.py
+++ b/examples/04_scalability.py
@@ -4,11 +4,19 @@ Scalability considerations for  similarity encoding
 
 """
 import warnings
+
+################################################################################
+# A tool to report memory usage and run time of a function
+# ---------------------------------------------------------
+#
+# For the sake of this example, we build a small tool that reports memory
+# usage and compute time of a function
 from time import time
 import functools
 import memory_profiler
 
 warnings.simplefilter(action='ignore', category=FutureWarning)
+
 
 def resource_used(func):
     """ Decorator that return a function that prints its usage
@@ -19,7 +27,8 @@ def resource_used(func):
         mem, out = memory_profiler.memory_usage((func, args, kwargs),
                                                 max_usage=True,
                                                 retval=True)
-        print("Time: %.1is    Memory used: %iMb" % (time() - t0, mem[0]))
+        print("Run time: %.1is    Memory used: %iMb"
+              % (time() - t0, mem[0]))
         return out
     return wrapped_func
 
@@ -41,7 +50,7 @@ import pandas as pd
 df = pd.read_csv(data['path'])
 
 # Limit to 50 000 rows, for a faster example
-df = df[:100000].copy()
+df = df[:50000].copy()
 df = df.dropna(axis=0)
 df = df.reset_index()
 ################################################################################
@@ -94,10 +103,10 @@ column_trans = ColumnTransformer(
     remainder='drop')
 
 
-#t0 = time()
-#X = column_trans.fit_transform(df)
-#t1 = time()
-#print('Time to vectorize: %s' % (t1 - t0))
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
 ################################################################################
 # We can run a cross-validation
 from sklearn import linear_model, pipeline, model_selection

--- a/examples/04_scalability.py
+++ b/examples/04_scalability.py
@@ -1,0 +1,257 @@
+"""
+Scalability considerations for  similarity encoding
+===================================================
+
+"""
+import warnings
+
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+################################################################################
+# Data Importing and preprocessing
+# --------------------------------
+#
+# We first download the dataset:
+from dirty_cat.datasets import fetch_traffic_violations
+
+data = fetch_traffic_violations()
+print(data['description'])
+
+################################################################################
+# Then we load it:
+import pandas as pd
+
+df = pd.read_csv(data['path'])
+
+# Limit to 50 000 rows, for a faster example
+df = df[:50000].copy()
+df = df.dropna(axis=0)
+df = df.reset_index()
+################################################################################
+# We will use SimilarityEncoder on the 'description' column. One
+# difficulty is that it many different entries
+print(df['Description'].nunique())
+
+################################################################################
+print(df['Description'].value_counts()[:30])
+
+################################################################################
+# As we will see,SimilarityEncoder takes a while on such data
+
+
+################################################################################
+# SimilarityEncoder with default options
+# --------------------------------------
+#
+# Let us build our vectorizer, using a ColumnTransformer to combine
+# one-hot encoding and similarity encoding
+from sklearn.preprocessing import OneHotEncoder
+from sklearn.compose import ColumnTransformer
+from dirty_cat import SimilarityEncoder
+
+print('\nBasic similarity encoding')
+
+sim_enc = SimilarityEncoder(similarity='ngram', handle_unknown='ignore')
+
+y = df['Violation Type']
+
+# clean columns
+transformers = [('one_hot', OneHotEncoder(sparse=False, handle_unknown='ignore'),
+                 ['Alcohol',
+                  'Arrest Type',
+                  'Belts',
+                  'Commercial License',
+                  'Commercial Vehicle',
+                  'Fatal',
+                  'Gender',
+                  'HAZMAT',
+                  'Property Damage',
+                  'Race',
+                  'Work Zone']),
+                ('pass', 'passthrough', ['Year']),
+                ]
+
+column_trans = ColumnTransformer(
+    # adding the dirty column
+    transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+    remainder='drop')
+
+from time import time
+
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
+################################################################################
+# We can run a cross-validation
+from sklearn import linear_model, pipeline, model_selection
+
+model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+t0 = time()
+print(model_selection.cross_val_score(model, X, y))
+t1 = time()
+print('Cross-validation time: %s' % (t1 - t0))
+
+
+################################################################################
+# SimilarityEncoder with hashing
+# -------------------------------
+#
+# The hashing trick can be used to speed up the computation for the ngram
+# similarity. This is an approximation, in the sense that collisions can
+# occur. The larger the hashing-dim, the less the chances of collisions,
+# hence the tighter the approximation.
+print('\nSimilarity encoding with hashing')
+
+sim_enc = SimilarityEncoder(similarity='ngram', handle_unknown='ignore',
+                            hashing_dim=2 ** 16)
+
+column_trans = ColumnTransformer(
+    # adding the dirty column
+    transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+    remainder='drop')
+
+from time import time
+
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
+
+################################################################################
+# Check now that prediction is still as good
+model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+t0 = time()
+print(model_selection.cross_val_score(model, X, y))
+t1 = time()
+print('Cross-validation time: %s' % (t1 - t0))
+
+
+################################################################################
+# SimilarityEncoder with most frequent strategy
+# ---------------------------------------------
+#
+# The most frequent strategy selects the n most frequent values in a dirty
+# categorical variable to reduce the dimensionality of the problem and thus
+# speed things up. We select manually the number of prototypes we want to use.
+
+print('\nSimilarity encoding with a most frequent strategy')
+
+sim_enc = SimilarityEncoder(similarity='ngram', categories='most_frequent', n_prototypes=100)
+
+column_trans = ColumnTransformer(
+    # adding the dirty column
+    transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+    remainder='drop')
+
+from time import time
+
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
+
+################################################################################
+# Check now that prediction is still as good
+model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+t0 = time()
+print(model_selection.cross_val_score(model, X, y))
+t1 = time()
+print('Cross-validation time: %s' % (t1 - t0))
+
+
+################################################################################
+# SimilarityEncoder with most frequent strategy and hashing
+# ---------------------------------------------------------
+#
+# Combining most frequent strategy and the hashing trick should speed things up
+#
+print('\nSimilarity encoding with a most frequent strategy and hashing')
+
+sim_enc = SimilarityEncoder(similarity='ngram', categories='most_frequent', n_prototypes=100, hashing_dim=2 ** 16)
+
+column_trans = ColumnTransformer(
+    # adding the dirty column
+    transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+    remainder='drop')
+
+from time import time
+
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
+
+################################################################################
+# Check now that prediction is still as good
+model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+t0 = time()
+print(model_selection.cross_val_score(model, X, y))
+t1 = time()
+print('Cross-validation time: %s' % (t1 - t0))
+
+
+################################################################################
+# SimilarityEncoder with k-means strategy
+# ---------------------------------------
+#
+# K-means strategy is also a dimensionality reduction technique. But we apply
+# a K-means and nearest neighbors algorithm to find the prototypes. The number
+# of prototypes is set manually.
+
+print('\nSimilarity encoding with a k-means strategy')
+
+sim_enc = SimilarityEncoder(similarity='ngram', categories='k-means', n_prototypes=100)
+
+column_trans = ColumnTransformer(
+    # adding the dirty column
+    transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+    remainder='drop')
+
+from time import time
+
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
+
+################################################################################
+# Check now that prediction is still as good
+model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+t0 = time()
+print(model_selection.cross_val_score(model, X, y))
+t1 = time()
+print('Cross-validation time: %s' % (t1 - t0))
+
+
+################################################################################
+# SimilarityEncoder with k-means strategy
+# ---------------------------------------
+#
+# K-means strategy is also a dimensionality reduction technique. But we apply
+# a K-means and nearest neighbors algorithm to find the prototypes. The number
+# of prototypes is set manually.
+
+print('\nSimilarity encoding with a k-means strategy and hashing')
+
+sim_enc = SimilarityEncoder(similarity='ngram', categories='k-means', n_prototypes=100, hashing_dim=2 ** 16)
+
+column_trans = ColumnTransformer(
+    # adding the dirty column
+    transformers=transformers + [('sim_enc', sim_enc, ['Description'])],
+    remainder='drop')
+
+from time import time
+
+t0 = time()
+X = column_trans.fit_transform(df)
+t1 = time()
+print('Time to vectorize: %s' % (t1 - t0))
+
+################################################################################
+# Check now that prediction is still as good
+model = pipeline.Pipeline([('logistic', linear_model.LogisticRegression())])
+t0 = time()
+print(model_selection.cross_val_score(model, X, y))
+t1 = time()
+print('Cross-validation time: %s' % (t1 - t0))


### PR DESCRIPTION
I added a parameter to the constructor of similarity to enable weighting the categories when a k-means strategy is used. The weights are the frequency of apparition of the categories.

The example is not fully finished, I'm gonna add some plotting. Just need some guidelines as how long the example can be and how much we want to stress the similarity encoder (like should I just take the benchmark use cases and make a really long file describing all the situations?)

The benchmark plots for different situations:
- 100 prototypes and 10 cross validations
- number of rows: 10k, nuniques, 20k, 50k and 100k
- activates weighting on k-mean strategy or not
- vectorizer: 
    - count
    - hash: 2 ** 14, 2 ** 16, 2 ** 18, 2 ** 20
- strategies:
    - most-frequent
    - k-means

We plot the scores by vectoriser and strategy and the time taken by vectoriser and strategy.
@pcerda @GaelVaroquaux 