### PR TITLE
Fix error when list of categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Release 0.0.6
 =============
 
+* **SimilarityEncoder**: Fix a bug that was preventing a ``SimilarityEncoder``
+  to be created when ``categories`` was a list.
+
 * **SimilarityEncoder**: Set the dtype passed to the ngram similarity
   to float32, which reduces memory consumption during encoding.
 

--- a/dirty_cat/similarity_encoder.py
+++ b/dirty_cat/similarity_encoder.py
@@ -192,7 +192,8 @@ class SimilarityEncoder(OneHotEncoder):
         self.n_prototypes = n_prototypes
         self.random_state = random_state
 
-        assert categories in [None, 'auto', 'k-means', 'most_frequent']
+        if not isinstance(categories, list):
+            assert categories in [None, 'auto', 'k-means', 'most_frequent']
         if categories in ['k-means', 'most_frequent'] and (n_prototypes is None or n_prototypes == 0):
             raise ValueError('n_prototypes expected None or a positive non null integer')
         if categories == 'auto' and n_prototypes is not None:

--- a/dirty_cat/test/test_similarity_encoder.py
+++ b/dirty_cat/test/test_similarity_encoder.py
@@ -4,6 +4,32 @@ from dirty_cat import similarity_encoder, string_distances
 from dirty_cat.similarity_encoder import get_kmeans_prototypes
 
 
+def test_specifying_categories():
+    # When creating a new SimilarityEncoder:
+    # - if categories = 'auto', the categories are the sorted, unique training
+    # set observations (for each column)
+    # - if categories is a list (of lists), the categories for each column are
+    # each item in the list
+
+    # In this test, we first find the sorted, unique categories in the training
+    # set, and create a SimilarityEncoder by giving it explicitly the computed
+    # categories. The test consists in making sure the transformed observations
+    # given by this encoder are equal to the transformed obervations in the
+    # case of a SimilarityEncoder created with categories = 'auto'
+
+    observations = [['bar'], ['foo']]
+    categories = [['bar', 'foo']]
+
+    sim_enc_with_cat = similarity_encoder.SimilarityEncoder(
+        categories=categories, ngram_range=(2, 3), similarity='ngram')
+    sim_enc_auto_cat = similarity_encoder.SimilarityEncoder(
+        ngram_range=(2, 3), similarity='ngram')
+
+    feature_matrix_with_cat = sim_enc_with_cat.fit_transform(observations)
+    feature_matrix_auto_cat = sim_enc_auto_cat.fit_transform(observations)
+
+    assert np.allclose(feature_matrix_auto_cat, feature_matrix_with_cat)
+
 def _test_similarity(similarity, similarity_f, hashing_dim=None, categories='auto', n_prototypes=None):
     if n_prototypes is None:
         X = np.array(['aa', 'aaa', 'aaab']).reshape(-1, 1)


### PR DESCRIPTION
Also increased the coverage a bit by adding a test about this feature (giving a list of categories to `SimilarityEncoder`).
The test relies on the `auto` behavior though, which may change, so @GaelVaroquaux if you are uncomforatable with it I can also simply check a hardcoded similarity matrix.