### PR TITLE
ENH accelerate ngram_similarity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-    - CONDA_DEPENDENCIES='python-Levenshtein distance sklearn numpy scipy requests pytest-cov codecov'
+    - CONDA_DEPENDENCIES='python-Levenshtein distance sklearn joblib numpy scipy requests pytest-cov codecov'
 python:
     - 3.6
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 Release 0.0.6
 =============
+* **SimilarityEncoder**: Accelerate ``SimilarityEncoder.transform``, by:
+
+  - computing the vocabulary count vectors in ``fit`` instead of ``transform``
+  - computing the similarities in parallel using ``joblib``. This option can be
+    turned on/off via the ``n_jobs`` attribute of the ``SimilarityEncoder``.
 
 * **SimilarityEncoder**: Fix a bug that was preventing a ``SimilarityEncoder``
   to be created when ``categories`` was a list.

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -117,7 +117,7 @@ conda update --yes --quiet conda
 conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx=1.6.2 \
-  seaborn pillow cython pandas="${PANDAS_VERSION:-*}"
+  seaborn pillow cython joblib pandas="${PANDAS_VERSION:-*}"
 #removed scikit learn from conda since it is installed from master after
 
 source activate testenv

--- a/dirty_cat/similarity_encoder.py
+++ b/dirty_cat/similarity_encoder.py
@@ -244,10 +244,6 @@ class SimilarityEncoder(OneHotEncoder):
         if categories == 'auto' and n_prototypes is not None:
             warnings.warn('n_prototypes parameter ignored with category type \'auto\'')
 
-        self._vectorizers = None
-        self._vocabulary_count_matrices = None
-        self._vocabulary_ngram_counts = None
-
     def get_most_frequent(self, prototypes):
         """ Get the most frequent category prototypes
         Parameters
@@ -314,9 +310,9 @@ class SimilarityEncoder(OneHotEncoder):
                 self.categories_.append(np.array(self.categories[i], dtype=object))
 
         if self.similarity == 'ngram':
-            self._vectorizers = []
-            self._vocabulary_count_matrices = []
-            self._vocabulary_ngram_counts = []
+            self.vectorizers_ = []
+            self.vocabulary_count_matrices_ = []
+            self.vocabulary_ngram_counts_ = []
 
             for i in range(n_features):
                 vectorizer = CountVectorizer(
@@ -338,9 +334,9 @@ class SimilarityEncoder(OneHotEncoder):
                 vocabulary_ngram_count = list(map(lambda x: get_ngram_count(
                     preprocess(x), self.ngram_range), self.categories_[i]))
 
-            self._vectorizers.append(vectorizer)
-            self._vocabulary_count_matrices.append(vocabulary_count_matrix)
-            self._vocabulary_ngram_counts.append(vocabulary_ngram_count)
+            self.vectorizers_.append(vectorizer)
+            self.vocabulary_count_matrices_.append(vocabulary_count_matrix)
+            self.vocabulary_ngram_counts_.append(vocabulary_ngram_count)
 
         return self
 
@@ -426,15 +422,15 @@ class SimilarityEncoder(OneHotEncoder):
             the column index of X in the original feature matrix.
         """
         min_n, max_n = self.ngram_range
-        vectorizer = self._vectorizers[col_idx]
+        vectorizer = self.vectorizers_[col_idx]
 
         unq_X = np.unique(X)
         unq_X_ = np.array(list(map(preprocess, unq_X)))
 
         X_count_matrix = vectorizer.transform(unq_X_)
-        vocabulary_count_matrix = self._vocabulary_count_matrices[col_idx]
+        vocabulary_count_matrix = self.vocabulary_count_matrices_[col_idx]
         vocabulary_ngram_count = np.array(
-            self._vocabulary_ngram_counts[col_idx]).reshape(-1, 1)
+            self.vocabulary_ngram_counts_[col_idx]).reshape(-1, 1)
 
         se_dict = {}
 

--- a/dirty_cat/similarity_encoder.py
+++ b/dirty_cat/similarity_encoder.py
@@ -13,10 +13,10 @@ from . import string_distances
 from .string_distances import get_ngram_count, preprocess
 
 
-def _ngram_similarity_one_sample(
+def _ngram_similarity_one_sample_inplace(
         x_count_vector, vocabulary_count_matrix, str_x,
         vocabulary_ngram_counts, se_dict, unq_X, i, ngram_range):
-    """Compute the similarity between one new sample and a vocabulary.
+    """Update inplace a dict of similarities between a string and a vocabulary
 
 
     Parameters
@@ -49,7 +49,6 @@ def _ngram_similarity_one_sample(
         str_x, ngram_range) + vocabulary_ngram_counts - samegrams
     similarity = np.divide(samegrams, allgrams)
     se_dict[unq_X[i]] = similarity.reshape(-1)
-
 
 
 def ngram_similarity(X, cats, ngram_range, hashing_dim, dtype=np.float64):
@@ -440,7 +439,7 @@ class SimilarityEncoder(OneHotEncoder):
         se_dict = {}
 
         Parallel(n_jobs=self.n_jobs, backend='threading')(delayed(
-            _ngram_similarity_one_sample)(
+            _ngram_similarity_one_sample_inplace)(
             X_count_vector, vocabulary_count_matrix, x_str,
             vocabulary_ngram_count, se_dict, unq_X, i, self.ngram_range) for
             X_count_vector, x_str, i in zip(

--- a/dirty_cat/test/test_similarity_encoder.py
+++ b/dirty_cat/test/test_similarity_encoder.py
@@ -30,6 +30,21 @@ def test_specifying_categories():
 
     assert np.allclose(feature_matrix_auto_cat, feature_matrix_with_cat)
 
+
+def test_fast_ngram_similarity():
+    vocabulary = [['bar', 'foo']]
+    observations = [['foo'], ['baz']]
+
+    sim_enc = similarity_encoder.SimilarityEncoder(
+        similarity='ngram', ngram_range=(2, 2), categories=vocabulary)
+
+    sim_enc.fit(observations)
+    feature_matrix = sim_enc.transform(observations, fast=False)
+    feature_matrix_fast = sim_enc.transform(observations, fast=True)
+
+    assert np.allclose(feature_matrix, feature_matrix_fast)
+
+
 def _test_similarity(similarity, similarity_f, hashing_dim=None, categories='auto', n_prototypes=None):
     if n_prototypes is None:
         X = np.array(['aa', 'aaa', 'aaab']).reshape(-1, 1)

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,6 @@ if __name__ == '__main__':
           platforms='any',
           packages=find_packages(),
           package_data={'dirty_cat': ['VERSION.txt', 'data/midwest_survey/*.csv']},
-          install_requires=['scikit-learn>=0.20', 'numpy', 'scipy', 'requests'],
+          install_requires=['scikit-learn>=0.20', 'numpy', 'scipy', 'requests',
+                            'joblib'],
           )


### PR DESCRIPTION
Accelerate the computation in `SimilarityEncoder.transform` by:

* Parallelizing the similarity computations using `joblib`
* Computing the count vectors of the vocabulary at fitting time and not at transform time. 