### PR TITLE
Fixed dirty_cat jaro_winkler implementation to match Levensthein.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@ Release 0.0.6
 =============
 * **SimilarityEncoder**: Fixed a bug when using the Jaro-Winkler distance as a
   similarity metric. Our implementation now accurately reproduces the behaviour
-  of the ``python-Levenstein`` implementation.
+  of the ``python-Levenshtein`` implementation.
 
 * **SimilarityEncoder**: Accelerate ``SimilarityEncoder.transform``, by:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Release 0.0.6
 =============
+* **SimilarityEncoder**: Fixed a bug when using the Jaro-Winkler distance as a
+  similarity metric. Our implementation now accurately reproduces the behaviour
+  of the ``python-Levenstein`` implementation.
+
 * **SimilarityEncoder**: Accelerate ``SimilarityEncoder.transform``, by:
 
   - computing the vocabulary count vectors in ``fit`` instead of ``transform``

--- a/dirty_cat/string_distances.py
+++ b/dirty_cat/string_distances.py
@@ -154,8 +154,8 @@ def _jaro_winkler(seq1, seq2, winkler=False):
     if not seq1_len or not seq2_len:
         return 0.0
 
-    min_len = max(seq1_len, seq2_len)
-    search_range = (min_len // 2) - 1
+    min_len = min(seq1_len, seq2_len)
+    search_range = (min_len + 1) // 2 # Same threshold as Levenshtein.jaro
     if search_range < 0:
         search_range = 0
 
@@ -195,7 +195,7 @@ def _jaro_winkler(seq1, seq2, winkler=False):
               (common_chars-trans_count) / common_chars)) / 3
 
     # winkler modification: continue to boost if strings are similar
-    if winkler and weight > 0.7 and seq1_len > 3 and seq2_len > 3:
+    if winkler:
         # adjust for up to first 4 chars in common
         j = min(min_len, 4)
         i = 0

--- a/dirty_cat/test/test_string_distances.py
+++ b/dirty_cat/test/test_string_distances.py
@@ -10,15 +10,15 @@ except ImportError:
 from dirty_cat import string_distances
 
 
-def _random_string_pairs(n_pairs=50):
-    rng = np.random.RandomState(0)
+def _random_string_pairs(n_pairs=50, seed=1):
+    rng = np.random.RandomState(seed)
     characters = list(map(chr, range(10000)))
     pairs = []
     for n in range(n_pairs):
         s1_len = rng.randint(50)
         s2_len = rng.randint(50)
-        s1 = ''.join(np.random.choice(characters, s1_len))
-        s2 = ''.join(np.random.choice(characters, s2_len))
+        s1 = ''.join(rng.choice(characters, s1_len))
+        s2 = ''.join(rng.choice(characters, s2_len))
         pairs.append((s1, s2))
     return pairs
 

--- a/dirty_cat/test/test_string_distances.py
+++ b/dirty_cat/test/test_string_distances.py
@@ -1,7 +1,6 @@
 import unittest
 
 import numpy as np
-import random
 
 try:
     import Levenshtein
@@ -23,20 +22,25 @@ def _random_string_pairs(n_pairs=50):
         pairs.append((s1, s2))
     return pairs
 
+
 def _random_common_char_pairs(n_pairs=50, seed=1):
     """
-    Return string pairs with a common char at random positions. This should
-    discriminate different thresholds for matching chararacters in Jaro distance.
+    Return string pairs with a common char at random positions, in order to
+    distinguish different thresholds for matching chararacters in Jaro
+    distance.
     """
     # Make strings with random length and common char at index 0
     rng = np.random.RandomState(seed=seed)
-    list1 = ['a'+'b'*rng.randint(2,20) for k in range(n_pairs)]
-    list2 = ['a'+'c'*rng.randint(2,20) for k in range(n_pairs)]
+    list1 = ['a' + 'b' * rng.randint(2, 20) for k in range(n_pairs)]
+    list2 = ['a' + 'c' * rng.randint(2, 20) for k in range(n_pairs)]
     # Shuffle strings
-    list1 = [''.join(rng.sample(s,len(s))) for s in list1]
-    list2 = [''.join(random.sample(s,len(s))) for s in list2]
+    list1 = [''.join(rng.choice(
+        list(s), size=len(s), replace=False)) for s in list1]
+    list2 = [''.join(rng.choice(
+        list(s), size=len(s), replace=False)) for s in list2]
     pairs = zip(list1, list2)
     return pairs
+
 
 # TODO: some factorization of what is common for distances;
 # check results for same examples on all distances
@@ -116,30 +120,24 @@ def test_compare_implementations():
     # Test on strings with randomly placed common char
     for string1, string2 in _random_common_char_pairs(n_pairs=50):
         assert (string_distances._jaro_winkler(string1, string2,
-                    winkler=False)
+                                               winkler=False)
                 == Levenshtein.jaro(string1, string2)
-               )
+                )
         assert (string_distances._jaro_winkler(string1, string2,
-                    winkler=True)
-                == Levenshtein.jaro_winkler(string1, string2)
-               )
+                                               winkler=True)
+                == Levenshtein.jaro_winkler(string1, string2))
         assert (string_distances.levenshtein_ratio(string1, string2)
-                == Levenshtein.ratio(string1, string2)
-               )
+                == Levenshtein.ratio(string1, string2))
     # Test on random strings
     for string1, string2 in _random_string_pairs(n_pairs=50):
         assert (string_distances._jaro_winkler(string1, string2,
-                    winkler=False)
-                == Levenshtein.jaro(string1, string2)
-               )
+                                               winkler=False)
+                == Levenshtein.jaro(string1, string2))
         assert (string_distances._jaro_winkler(string1, string2,
-                    winkler=True)
-                == Levenshtein.jaro_winkler(string1, string2)
-               )
+                                               winkler=True)
+                == Levenshtein.jaro_winkler(string1, string2))
         assert (string_distances.levenshtein_ratio(string1, string2)
-                == Levenshtein.ratio(string1, string2)
-               )
-
+                == Levenshtein.ratio(string1, string2))
 
 
 def test_ngram_similarity():


### PR DESCRIPTION
Should resolve issue #115. There was 2 problems with our implementation of the Jaro and Jaro-Winkler distance.
- `search_range`, i.e. the maximum range when matching characters was different: `max_len // 2 -1` against `(min_len - 1) // 2`.
- In some cases like `min_len <= 3`, the Jaro-Winkler distance wasn't computed even though we set `winkler=True`.

I also added more thorough tests in `test_compare_implementations`. It should now discriminate implementations with different `search_range`.