### PR TITLE
Fix example 05 to check for empty chunks

### DIFF
--- a/examples/05_scaling_non_linear_models.py
+++ b/examples/05_scaling_non_linear_models.py
@@ -439,6 +439,9 @@ iter_csv = pd.read_csv(
 
 for batch_no, batch in enumerate(iter_csv):
     X_batch, y_batch = preprocess(batch, label_encoder)
+    # skip iteration if batch is empty after preprocessing
+    if len(y_batch) == 0:
+        continue
     X_batch_kernel_approx, y_batch_onehot = encode(
         X_batch, y_batch, one_hot_encoder, column_transformer, rbf_sampler)
 


### PR DESCRIPTION
There was some issue with example 05 that prevented CircleCI to build the doc with sphinx.
When performing online training on chunks of a dataframe, one of the chunks is empty after the preprocessing step and thus cannot be used for training. I simply added a test to check for empty chunks and skip iterations if needed.