### PR TITLE
Fix: Minhash encoder does not perform well on the dirty-cat examples

### DIFF
--- a/dirty_cat/minhash_encoder.py
+++ b/dirty_cat/minhash_encoder.py
@@ -38,7 +38,8 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     n_components : int
-        The number of dimension of encoded strings.
+        The number of dimension of encoded strings. Numbers around 300 tend to
+        lead to good prediction performance, but with more computational cost.
     ngram_range : tuple (min_n, max_n), default=(2, 4)
         The lower and upper boundary of the range of n-values for different
         n-grams to be extracted. All values of n such that min_n <= n <= max_n.

--- a/dirty_cat/minhash_encoder.py
+++ b/dirty_cat/minhash_encoder.py
@@ -57,7 +57,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
     
     """
 
-    def __init__(self, n_components, ngram_range=(2, 4),
+    def __init__(self, n_components=30, ngram_range=(2, 4),
                  hashing='fast', minmax_hash=False):
         self.ngram_range = ngram_range
         self.n_components = n_components

--- a/examples/02_fit_predict_plot_employee_salaries.py
+++ b/examples/02_fit_predict_plot_employee_salaries.py
@@ -73,7 +73,7 @@ encoders_dict = {
     'one-hot': OneHotEncoder(handle_unknown='ignore', sparse=False),
     'similarity': SimilarityEncoder(similarity='ngram'),
     'target': TargetEncoder(handle_unknown='ignore'),
-    'minhash': MinHashEncoder(n_components=10, ngram_range=(2, 4),
+    'minhash': MinHashEncoder(n_components=100, ngram_range=(2, 4),
                               hashing='fast', minmax_hash=False),
     'numerical': FunctionTransformer(None)}
 
@@ -130,11 +130,11 @@ for method in encoding_methods:
 # Plotting the results
 # --------------------
 # Finally, we plot the scores on a boxplot:
-# We notice that the MinHashEncoder performs poorly compared to other encoding
-# methods. There are two reasons for that: the MinHashEncoder performs better
-# with tree-based models than linear models (see example 03), and the
-# low-dimensionality of encodings (increasing n_components improves
-# performances.
+# We notice that the MinHashEncoder does not performs as well compared to 
+# other encoding methods.
+# There are two reasons for that: the MinHashEncoder performs better
+# with tree-based models than linear models (see example 03), and also
+# increasing n_components improves performances.
 
 import seaborn
 import matplotlib.pyplot as plt

--- a/examples/02_fit_predict_plot_employee_salaries.py
+++ b/examples/02_fit_predict_plot_employee_salaries.py
@@ -73,8 +73,7 @@ encoders_dict = {
     'one-hot': OneHotEncoder(handle_unknown='ignore', sparse=False),
     'similarity': SimilarityEncoder(similarity='ngram'),
     'target': TargetEncoder(handle_unknown='ignore'),
-    'minhash': MinHashEncoder(n_components=100, ngram_range=(2, 4),
-                              hashing='fast', minmax_hash=False),
+    'minhash': MinHashEncoder(n_components=100),
     'numerical': FunctionTransformer(None)}
 
 # We then create a function that takes one key of our ``encoders_dict``,

--- a/examples/02_fit_predict_plot_employee_salaries.py
+++ b/examples/02_fit_predict_plot_employee_salaries.py
@@ -134,7 +134,7 @@ for method in encoding_methods:
 # other encoding methods.
 # There are two reasons for that: the MinHashEncoder performs better
 # with tree-based models than linear models (see example 03), and also
-# increasing n_components improves performances. n_components around 300 
+# increasing `n_components` improves performances. `n_components` around 300 
 # tend to lead to good prediction performance, but with more computational
 # cost.
 

--- a/examples/02_fit_predict_plot_employee_salaries.py
+++ b/examples/02_fit_predict_plot_employee_salaries.py
@@ -133,7 +133,7 @@ for method in encoding_methods:
 # other encoding methods.
 # There are two reasons for that: the MinHashEncoder performs better
 # with tree-based models than linear models (
-# :ref:`see example 03<sphx_glr_auto_examples_03_fit_predict_plot_midwest_survey.html#sphx-glr-auto-examples-03-fit-predict-plot-midwest-survey-py>`)
+# :ref:`see example 03<sphx_glr_auto_examples_03_fit_predict_plot_midwest_survey.py>`)
 # , and also
 # increasing `n_components` improves performances. `n_components` around 300 
 # tend to lead to good prediction performance, but with more computational

--- a/examples/02_fit_predict_plot_employee_salaries.py
+++ b/examples/02_fit_predict_plot_employee_salaries.py
@@ -132,7 +132,9 @@ for method in encoding_methods:
 # We notice that the MinHashEncoder does not performs as well compared to 
 # other encoding methods.
 # There are two reasons for that: the MinHashEncoder performs better
-# with tree-based models than linear models (see example 03), and also
+# with tree-based models than linear models (
+# :ref:`see example 03<sphx_glr_auto_examples_03_fit_predict_plot_midwest_survey.html#sphx-glr-auto-examples-03-fit-predict-plot-midwest-survey-py>`)
+# , and also
 # increasing `n_components` improves performances. `n_components` around 300 
 # tend to lead to good prediction performance, but with more computational
 # cost.

--- a/examples/02_fit_predict_plot_employee_salaries.py
+++ b/examples/02_fit_predict_plot_employee_salaries.py
@@ -134,7 +134,9 @@ for method in encoding_methods:
 # other encoding methods.
 # There are two reasons for that: the MinHashEncoder performs better
 # with tree-based models than linear models (see example 03), and also
-# increasing n_components improves performances.
+# increasing n_components improves performances. n_components around 300 
+# tend to lead to good prediction performance, but with more computational
+# cost.
 
 import seaborn
 import matplotlib.pyplot as plt

--- a/examples/03_fit_predict_plot_midwest_survey.py
+++ b/examples/03_fit_predict_plot_midwest_survey.py
@@ -69,7 +69,7 @@ from dirty_cat import SimilarityEncoder, MinHashEncoder
 encoder_dict = {
     'one-hot': OneHotEncoder(handle_unknown='ignore', sparse=False),
     'similarity': SimilarityEncoder(similarity='ngram'),
-    'minhash': MinHashEncoder(n_components=10, ngram_range=(2, 4),
+    'minhash': MinHashEncoder(n_components=30, ngram_range=(2, 4),
                               hashing='fast', minmax_hash=False),
     'num': FunctionTransformer(None)
 }
@@ -135,5 +135,5 @@ plt.yticks(size=20)
 plt.tight_layout()
 
 ###############################################################################
-# We can see that encoding the data using a SimilarityEncoder instead of
-# OneHotEncoder helps a lot in improving the cross validation score!
+# We can see that encoding the data using a SimilarityEncoder or MinhashEncoder
+# instead of OneHotEncoder helps a lot in improving the cross validation score!

--- a/examples/03_fit_predict_plot_midwest_survey.py
+++ b/examples/03_fit_predict_plot_midwest_survey.py
@@ -69,8 +69,7 @@ from dirty_cat import SimilarityEncoder, MinHashEncoder
 encoder_dict = {
     'one-hot': OneHotEncoder(handle_unknown='ignore', sparse=False),
     'similarity': SimilarityEncoder(similarity='ngram'),
-    'minhash': MinHashEncoder(n_components=30, ngram_range=(2, 4),
-                              hashing='fast', minmax_hash=False),
+    'minhash': MinHashEncoder(),
     'num': FunctionTransformer(None)
 }
 ##############################################################################


### PR DESCRIPTION
Fix #127  

In example 02, puting `n_components` = 300 gives results as good as one_hot_encoder (.85) but it take more time.
I put  `n_components` = 100 to have decent results.