### PR TITLE
replace sklearn assert function with pytest and changes.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Release 0.0.8
+=============
+
+* **MinHashEncoder**: Added a "handle_missing" attribute to allow encoding
+  with missing values.
+
 Release 0.0.7
 =============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,3 @@
-Release 0.0.8
-=============
-
-* **MinHashEncoder**: Added a "handle_missing" attribute to allow encoding
-  with missing values.
-
 Release 0.0.7
 =============
 
@@ -26,6 +20,9 @@ Release 0.0.7
   with missing values.
 
 * **TargetEncoder**: Added a "handle_missing" attribute to allow encoding
+  with missing values.
+
+* **MinHashEncoder**: Added a "handle_missing" attribute to allow encoding
   with missing values.
 
 Release 0.0.6

--- a/dirty_cat/test/test_similarity_encoder.py
+++ b/dirty_cat/test/test_similarity_encoder.py
@@ -1,6 +1,5 @@
 import numpy as np
 import numpy.testing
-from sklearn.utils._testing import assert_raise_message
 from dirty_cat import similarity_encoder, string_distances
 from dirty_cat.similarity_encoder import get_kmeans_prototypes
 import pytest
@@ -64,18 +63,17 @@ def _test_missing_values(input_type, missing):
 
     sim_enc = similarity_encoder.SimilarityEncoder(handle_missing=missing)
     if missing == 'error':
-        try:
+        with pytest.raises(ValueError, match=r"Found missing values in input "
+                           "data; set handle_missing='' to encode "
+                           "with missing values"):
             sim_enc.fit_transform(observations)
-        except ValueError as e:
-            assert e.__str__() == ("Found missing values in input data; set "
-                                   "handle_missing='' to encode with missing values")
-            return
     elif missing == '':
         ans = sim_enc.fit_transform(observations)
         assert np.allclose(encoded, ans)
     else:
-        msg = "handle_missing should be either 'error' or '', got %s" % missing
-        assert_raise_message(ValueError, msg, sim_enc.fit_transform, observations)
+        with pytest.raises(ValueError, match=r"handle_missing"
+                           " should be either 'error' or ''"):
+            sim_enc.fit_transform(observations)
         return
 
 
@@ -99,12 +97,10 @@ def _test_missing_values_transform(input_type, missing):
     sim_enc = similarity_encoder.SimilarityEncoder(handle_missing=missing)
     if missing == 'error':
         sim_enc.fit_transform(observations)
-        try:
+        with pytest.raises(ValueError, match=r"Found missing values in input "
+                           "data; set handle_missing='' to encode "
+                           "with missing values"):
             sim_enc.transform(test_observations)
-        except ValueError as e:
-            assert e.__str__() == ("Found missing values in input data; set "
-                                   "handle_missing='' to encode with missing values")
-            return
     elif missing == '':
         sim_enc.fit_transform(observations)
         ans = sim_enc.transform(test_observations)

--- a/dirty_cat/test/test_target_encoder.py
+++ b/dirty_cat/test/test_target_encoder.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-from sklearn.utils._testing import assert_raise_message
 
 from dirty_cat import target_encoder
 
@@ -233,9 +232,10 @@ def _test_missing_values(input_type, missing):
 
     encoder = target_encoder.TargetEncoder(handle_missing=missing)
     if missing == 'error':
-        msg = ("Found missing values in input data; set "
-               "handle_missing='' to encode with missing values")
-        assert_raise_message(ValueError, msg, encoder.fit_transform, X, y)
+        with pytest.raises(ValueError, match=r"Found missing values in input "
+                           "data; set handle_missing='' to encode "
+                           "with missing values"):
+            encoder.fit_transform(X, y)
         return
     elif missing == '':
         encoder.fit_transform(X, y)
@@ -248,8 +248,9 @@ def _test_missing_values(input_type, missing):
         assert dict(encoder.counter_[0]) == count_['color']
         assert dict(encoder.counter_[1]) == count_['gender']
     else:
-        msg = "handle_missing should be either 'error' or '', got %s" % missing
-        assert_raise_message(ValueError, msg, encoder.fit_transform, X, y)
+        with pytest.raises(ValueError, match=r"handle_missing"
+                           " should be either 'error' or ''"):
+            encoder.fit_transform(X, y)
         return
 
 
@@ -304,9 +305,10 @@ def _test_missing_values_transform(input_type, missing):
                                            handle_missing=missing)
     if missing == 'error':
         encoder.fit_transform(X, y)
-        msg = ("Found missing values in input data; set "
-               "handle_missing='' to encode with missing values")
-        assert_raise_message(ValueError, msg, encoder.transform, X_test)
+        with pytest.raises(ValueError, match=r"Found missing values in input "
+                           "data; set handle_missing='' to encode "
+                           "with missing values"):
+            encoder.transform(X_test)
         return
     elif missing == '':
         encoder.fit_transform(X, y)


### PR DESCRIPTION
Changes:
- Replaced sklearn's assert_raise_message() with pytest raises in target and similarity encoder.
- update to changes.rst for minhash handle_missing functionality.