### PR TITLE
Minor modification to avoid ConvergenceWarnings in Notebook 04.

### DIFF
--- a/examples/04_dimension_reduction_and_performance.py
+++ b/examples/04_dimension_reduction_and_performance.py
@@ -116,7 +116,7 @@ print('Time to vectorize: %s' % (t1 - t0))
 # We can run a cross-validation
 from sklearn import linear_model, pipeline, model_selection
 
-# We add max_iter to avoid ConvergenceWarning
+# We specify max_iter to avoid convergence warnings
 log_reg = linear_model.LogisticRegression(max_iter=10000)
 
 model = pipeline.make_pipeline(column_trans, log_reg)

--- a/examples/04_dimension_reduction_and_performance.py
+++ b/examples/04_dimension_reduction_and_performance.py
@@ -116,7 +116,8 @@ print('Time to vectorize: %s' % (t1 - t0))
 # We can run a cross-validation
 from sklearn import linear_model, pipeline, model_selection
 
-log_reg = linear_model.LogisticRegression()
+# We add max_iter to avoid ConvergenceWarning
+log_reg = linear_model.LogisticRegression(max_iter=10000)
 
 model = pipeline.make_pipeline(column_trans, log_reg)
 results = resource_used(model_selection.cross_validate)(model, df, y, )


### PR DESCRIPTION
Added max_iter argument to the LogisticRegression instantiation in Notebook 04.
Solves "Warning messages in notebook 04_dimension_reduction_and_performance #140".

Source: https://stackoverflow.com/a/62113936
By the way, as mentioned in the answer:
> You may also standardize your data as the warning said, with `sklearn.preprocessing.scale()`.
