### PR TITLE
Add github action artifact link redirector

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+# Display a link to the artifacts at the bottom of a PR
+# from https://github.com/marketplace/actions/run-circleci-artifacts-redirector
+on: [status]
+jobs:
+    circleci_artifacts_redirector_job:
+        runs-on: ubuntu-latest
+        name: Run CircleCI artifacts redirector
+        steps:
+            - name: GitHub Action step
+              id: step1
+              uses: larsoner/circleci-artifacts-redirector-action@master
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN  }}
+                  artifact-path: 0/doc/_build/html/index.html
+                  circleci-jobs: python3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,5 @@ jobs:
               uses: larsoner/circleci-artifacts-redirector-action@master
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN  }}
-                  artifact-path: 0/doc/_build/html/index.html
+                  artifact-path: 0/doc/index.html
                   circleci-jobs: python3


### PR DESCRIPTION
Closes #111

This should be the equivalent to what I've done for nilearn.