### PR TITLE
Fix CircleCI checks [doc build]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ jobs:
       - run: ./build_tools/circle/checkout_merge_commit.sh
       - restore_cache:
           key: v1-datasets-{{ .Branch }}
-      - run: ./build_tools/circle/build_doc.sh
+      - run:
+          command: ./build_tools/circle/build_doc.sh
+          no_output_timeout: 30m
       - store_artifacts:
           path: doc/_build/html
           destination: doc

--- a/examples/05_scaling_non_linear_models.py
+++ b/examples/05_scaling_non_linear_models.py
@@ -413,7 +413,7 @@ X_test_kernel_approx, y_true_test_onehot = encode(
 # We now have all the theoretical elements to create an non-linear, online
 # kernel method.
 import warnings
-from sklearn.linear_model.stochastic_gradient import SGDClassifier
+from sklearn.linear_model import SGDClassifier
 
 online_train_set_size = 100000
 # Filter warning on max_iter and tol


### PR DESCRIPTION
CircleCI checks didn't pass after the last PR. When building example 05 in the documentation, an import error is raised when executing `from sklearn.linear_model.stochastic_gradient import SGDClassifier`. Since sklearn 0.22, it should be imported with `from sklearn.linear_model import SGDClassifier`instead, so I changed that line of code.

However I wonder why this error wasn't raised before. Maybe when merging PR to master, CircleCI doesn't build examples that weren't modified.

