### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Something not working as described? This is the place.
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+<!--Provide a brief description of the bug.-->
+
+
+<!--Please fill in the following information, to the best of your ability.-->
+dirty_cat version:
+
+### Expected behavior
+
+
+### Actual behavior
+
+
+### Steps and code to reproduce bug
+
+```python
+
+```

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation
+about: Request an improvement to the existing documentation.
+title: ''
+labels: Documentation
+assignees: ''
+---
+<!--Describe your proposed enhancement in detail.-->
+
+<!--List any pages that would be impacted by the enhancement.-->
+### Affected pages

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Got an idea for a new feature, or changing an existing one? This is the place.
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+<!--Provide a brief description what you would like changes and why.-->
+
+
+<!--Please fill in the following information, to the best of your ability.-->
+### Benefits to the change
+
+
+### Pseudocode for the new behavior, if applicable
+
+```python
+
+```


### PR DESCRIPTION
Related to #196 

@LilianBoulard AFAIK, random users cannot put labels on issues (I believe only contributors can...). I think the reason behind this is that users are not supposed to know your labeling conventions, and therefore they are not the best persons to decide which labels should be used.
However, most users opening an issue know whether it is to report a bug, ask for a new feature, say something about the documentation, and so on...
This PR proposes to add a few issue templates with predefined text and labels in order to ease this process. Namely:

- a bug report template
- a documentation template
- a feature request template

Note that you can easily add/remove them (maybe you'll also need a usage question template and so on...).

Feel free to close this if you don't think it's relevant :wink: 