### PR TITLE
Bump minimal requirement for sklearn from 0.20.0 to 0.21.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+Release 0.2.0
+=============
+
+Also see pre-release 0.2.0a1 below for additional changes.
+
+Major changes
+-------------
+
+* Bump minimum dependencies:
+
+  - scikit-learn (>=0.21.0)
+
 Release 0.2.0a1
 ===============
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 numpy==1.16
 scipy==1.2
-scikit-learn==0.20.0
+scikit-learn==0.21.0
 pytest
 pytest-cov
 coverage

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ if __name__ == '__main__':
           platforms='any',
           packages=find_packages(),
           package_data={'dirty_cat': ['VERSION.txt', 'data/midwest_survey/*.csv']},
-          install_requires=['scikit-learn>=0.20', 'numpy>=1.16', 'scipy>=1.2', 'requests',
+          install_requires=['scikit-learn>=0.21', 'numpy>=1.16', 'scipy>=1.2', 'requests',
                             'joblib'],
           )


### PR DESCRIPTION
Necessary for #155 and #200

Approved by @GaelVaroquaux 