### PR TITLE
Typo in CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Release 0.2.0a1
 Version 0.2.0a1 is a pre-release.
 To try it, you have to install it manually using::
 
-    pip install -pre dirty_cat==0.2.0a1
+    pip install --pre dirty_cat==0.2.0a1
 
 or from the GitHub repository::
 


### PR DESCRIPTION
For `pip install`, it's `--pre`, not `-pre`