### PR TITLE
Fix memory leak in notebook 6

### DIFF
--- a/examples/06_dimension_reduction_and_performance.py
+++ b/examples/06_dimension_reduction_and_performance.py
@@ -60,10 +60,8 @@ print(data['description'])
 # Then we load it:
 import pandas as pd
 
-df = pd.read_csv(data['path'])
-
 # Limit to 50 000 rows, for a faster example
-df = df[:50000].copy()
+df = pd.read_csv(data['path'], nrows=50000)
 df = df.dropna(axis=0)
 df = df.reset_index()
 ################################################################################


### PR DESCRIPTION
As pointed out in #155, there is a memory leak responsible for the CI errors.

This commit should lower the used memory of notebook 6 from ~1.3 GB to ~200 MB (measured with `tracemalloc` and `memory_profiler`), as well as making the build a little faster.