### PR TITLE
Modernize README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,19 @@
 dirty_cat
 =========
 
+.. image:: https://dirty-cat.github.io/stable/_static/dirty_cat.svg
+   :align: center
+   :alt: dirty_cat logo
+
+
+|py_ver| |pypi_var| |pypi_dl| |codecov| |circleci|
+
+.. |py_ver| image:: https://img.shields.io/pypi/pyversions/dirty_cat
+.. |pypi_var| image:: https://img.shields.io/pypi/v/dirty_cat?color=informational
+.. |pypi_dl| image:: https://img.shields.io/pypi/dm/dirty_cat
+.. |codecov| image:: https://img.shields.io/codecov/c/github/dirty-cat/dirty_cat/master
+.. |circleci| image:: https://img.shields.io/circleci/build/github/dirty-cat/dirty_cat/master?label=CircleCI
+
 dirty_cat is a Python module for machine-learning on dirty categorical variables.
 
 Website: https://dirty-cat.github.io/
@@ -21,7 +34,7 @@ dirty_cat requires:
 - Python (>= 3.6)
 - NumPy (>= 1.16)
 - SciPy (>= 1.2)
-- scikit-learn (>= 0.20.0)
+- scikit-learn (>= 0.21.0)
 
 Optional dependency:
 


### PR DESCRIPTION
This is a minor proposal for modernizing the README:
- Added the dirty_cat logo
- Added 5 badges (with https://shields.io):
  - Supported Python versions (pulled from PyPi)
  - Current release version on PyPi
  - Monthly PyPi downloads
  - Code coverage
  - CircleCI status for `master`
- Modified the scikit-learn minimal dependency, should have been changed with #202 

See https://github.com/LilianBoulard/dirty_cat/tree/modernize_readme for the render

Inspired from [scikit-learn's README](https://github.com/scikit-learn/scikit-learn/blob/main/README.rst)