### PR TITLE
Add a handle_unknown parameter to the SuperVectorizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Major changes
 * Add a method "get_feature_names_out" for the **GapEncoder** and the **SuperVectorizer**,
   since "get_feature_names" will be depreciated in scikit-learn 1.2 (#216).
 
+* Add a `handle_unknown` parameter to the `SuperVectorizer` to deal with categories
+  that are not in the training set.
+
 Notes
 -----
 

--- a/dirty_cat/test/test_similarity_encoder.py
+++ b/dirty_cat/test/test_similarity_encoder.py
@@ -244,3 +244,18 @@ def test_get_features():
         'x0_z', 'x0_{', 'x0_|', 'x0_}', 'x0_~'
     ]
 
+def test_handle_unknown():
+    X = np.array(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m"]).reshape((-1, 1))
+    #X = pd.DataFrame(X)
+    X_train = X[:10]
+
+    sim_enc = similarity_encoder.SimilarityEncoder(random_state=235, handle_unknown='ignore')
+    sim_enc.fit(X_train)
+    sim_enc.transform(X)
+    with pytest.raises(ValueError,
+                       match="Found unknown categories \['k' 'l' 'm'\] in column 0 during transform"):
+        sim_enc = similarity_encoder.SimilarityEncoder(random_state=235, handle_unknown='error')
+        sim_enc.fit(X_train)
+        sim_enc.transform(X)
+
+

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -106,7 +106,7 @@ def _test_possibilities(
     check_same_transformers(expected_transformers_np_cast, vectorizer_cast.transformers)
 
     # Test handle_unknown
-    for encoder in [OneHotEncoder(), OrdinalEncoder()]:
+    for encoder in [OneHotEncoder(), OrdinalEncoder(), TargetEncoder()]:
         for handle_unknown in ["error", "ignore"]:
             vectorizer_unknown = SuperVectorizer(
                 cardinality_threshold=4,
@@ -120,10 +120,10 @@ def _test_possibilities(
                 with pytest.raises(ValueError,
                                    match="Found unknown categories \['30K\+'\] in column 0 during transform"):
                     # y needed for TargetEncoder and ignored otherwise
-                    vectorizer_unknown.fit(pd.DataFrame(X['cat2'][:3]), y=[1, 1, 2])
+                    vectorizer_unknown.fit(pd.DataFrame(X['cat2'][:3]), y=np.array([1, 1, 2]))
                     vectorizer_unknown.transform(pd.DataFrame(X['cat2'][:-1]))
             elif handle_unknown == "ignore":
-                vectorizer_unknown.fit(pd.DataFrame(X['cat2'][:3]), y=[1, 1, 2])
+                vectorizer_unknown.fit(pd.DataFrame(X['cat2'][:3]), y=np.array([1, 1, 2]))
                 vectorizer_unknown.transform(pd.DataFrame(X['cat2'][:-1]))
 
 

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -126,7 +126,17 @@ def _test_possibilities(
                 vectorizer_unknown.fit(pd.DataFrame(X['cat2'][:3]), y=np.array([1, 1, 2]))
                 vectorizer_unknown.transform(pd.DataFrame(X['cat2'][:-1]))
 
-
+    # Check that custom encoders parameters are not overwritten
+    encoder = OneHotEncoder(handle_unknown="ignore")
+    vectorizer_unknown = SuperVectorizer(
+        cardinality_threshold=4,
+        low_card_cat_transformer=encoder,
+        high_card_cat_transformer=GapEncoder(n_components=2),
+        numerical_transformer=StandardScaler(),
+        handle_unknown="error"
+    )
+    vectorizer_unknown.fit(pd.DataFrame(X['cat2'][:3]), y=np.array([1, 1, 2]))
+    vectorizer_unknown.transform(pd.DataFrame(X['cat2'][:-1]))
 
 def test_with_clean_data():
     """


### PR DESCRIPTION
#230 

I only use this parameter for low_card_cat_encoder, because I think that raising error for unknown categories in the high cardinality setting isn't reasonable.

If the user specifies an encoder with handle_unknown != error for low_card_cat_encoder, we don't overwrite his choice.
This idea is that this means that the user wanted to change default parameters.

I made the assumptions that for low_card_cat_encoder, we only needed to support:
- OneHotEncoder
- TargetEncoder
- OrdinalEncoder (in this case, if handle_unknown = "ignore"), the missing category is replaced by np.nan

