### PR TITLE
add a get_transformers() method to the SuperVectorizer()

### DIFF
--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -439,3 +439,14 @@ class SuperVectorizer(ColumnTransformer):
         get_feature_names.
         """
         return self.get_feature_names()
+
+    def get_transformers(self):
+        res  = []
+        for name, trans, cols in self.transformers_:
+            if name == "remainder":
+                res.append((name, trans,
+                            list(map(lambda i:self.columns_[i], cols))))
+            else:
+                res.append((name, trans, cols))
+        return res
+

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -249,6 +249,13 @@ def test_transform():
     x_trans = sup_vec.transform(x)
     assert (x_trans == [[1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 34, 5.5]]).all()
 
+def test_get_transformers():
+    X = _get_dirty_dataframe()
+    sup_vec = SuperVectorizer()
+    sup_vec.fit_transform(X)
+    trans = sup_vec.get_transformers()
+    assert trans[0][2] ==['str1', 'str2', 'cat1', 'cat2']
+    assert trans[1][2] == ['int', 'float']
 
 def fit_transform_equiv():
     """

--- a/examples/01_dirty_categories.py
+++ b/examples/01_dirty_categories.py
@@ -298,7 +298,7 @@ X_train_enc
 #
 # The |SV| assigns a transformer for each column. We can inspect this
 # choice:
-sup_vec.transformers_
+sup_vec.get_transformers()
 
 # %%
 # This is what is being passed to the |ColumnTransformer| under the hood.


### PR DESCRIPTION
Solving #232 , i.e the columns associated with the "remainder" transformer should be displayed by their names, not their index.

I tried to change the output of `sup_vec.transformers_` but it seems to be hard without changing the code of the ColumnTransformer, or doing weird hacks.

Instead, I created a new method `get_transformers()` which outputs the right result, but I'm not sure if creating a new method is a good idea.