### PR TITLE
Change auto_cast in SuperVectorizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+Release 0.2.1
+=============
+
+Major changes
+-------------
+
+Notes
+-----
+
+* Improvements to the SuperVectorizer
+
+    - Type detection works better: handles dates, numerics columns encoded as strings, or numeric columns containing strings for missing values
+
+
 Release 0.2.0
 =============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Major changes
 Notes
 -----
 
-* Improvements to the SuperVectorizer
+* Improvements to the :class:`SuperVectorizer`
 
     - Type detection works better: handles dates, numerics columns encoded as strings, or numeric columns containing strings for missing values
 

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -199,7 +199,7 @@ class SuperVectorizer(ColumnTransformer):
                     X[col] = X[col].astype(np.float64)
                 X[col].fillna(value=np.nan, inplace=True)
         STR_NA_VALUES = ['null', '', '1.#QNAN', '#NA', 'nan', '#N/A N/A', '-1.#QNAN', '<NA>', '-1.#IND', '-nan', 'n/a',
-                         '-NaN', '1.#IND', 'NULL', 'NA', 'N/A', '#N/A', 'NaN'] #taken from pandas
+                         '-NaN', '1.#IND', 'NULL', 'NA', 'N/A', '#N/A', 'NaN']  # taken from pandas.io.parsers (version 1.1.4)
         X = X.replace(STR_NA_VALUES + [None, "?", "..."],
                       np.nan)
         X = X.replace(r'^\s+$', np.nan, regex=True) # replace whitespace only
@@ -252,7 +252,6 @@ class SuperVectorizer(ColumnTransformer):
         if self.auto_cast:
             X = self._auto_cast(X)
             self.types_ = {c: t for c, t in zip(X.columns, X.dtypes)}
-        # Check the number of columns matches the fitted array's.
         if X.shape[1] != len(self.columns_):
             raise ValueError("Passed array does not match column count of "
                              f"array seen at fit time. Got {X.shape[0]} "

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -195,10 +195,16 @@ class SuperVectorizer(ColumnTransformer):
 
         parser = pd.io.parsers.TextParser(X,
                                           header=None,
-                                          na_values=[None, " ", "?", "..."],  # additional values to be considered as NA
-                                          infer_datetime_format=True,  # speed-up the date conversion
-                                          parse_dates=list(range(len(X[0]))))  # parse for all columns
+                                          na_values=[None, " ", "?", "..."])  # additional values to be considered as NA
         X = parser.read()
+
+        for col in X.columns:
+            # only convert string, object or categorical columns to datetimes
+            if X[col].dtype != "int64" and X[col].dtype != "float64":
+                try:
+                    X[col] = pd.to_datetime(X[col], errors='raise')
+                except:
+                    pass
 
         if colnames is not None:
             X.columns = colnames  # restore the column names
@@ -252,7 +258,7 @@ class SuperVectorizer(ColumnTransformer):
 
         # If the DataFrame does not have named columns already,
         # apply the learnt columns
-        if isinstance(X.columns, pd.RangeIndex) or isinstance(X.columns, pd.Int64Index):
+        if X.columns.dtype == "int64":
             X.columns = self.columns_
 
         for col in self.imputed_columns_:

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -254,7 +254,7 @@ class SuperVectorizer(ColumnTransformer):
             self.types_ = {c: t for c, t in zip(X.columns, X.dtypes)}
         if X.shape[1] != len(self.columns_):
             raise ValueError("Passed array does not match column count of "
-                             f"array seen at fit time. Got {X.shape[0]} "
+                             f"array seen at fit time. Got {X.shape[1]} "
                              f"columns, expected {len(self.columns_)}")
 
         # If the DataFrame does not have named columns already,

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -201,7 +201,7 @@ class SuperVectorizer(ColumnTransformer):
 
         for col in X.columns:
             # only convert string, object or categorical columns to datetimes
-            if X[col].dtype != "int64" and X[col].dtype != "float64":
+            if not pd.api.types.is_numeric_dtype(X[col]):
                 try:
                     X[col] = pd.to_datetime(X[col], errors='raise')
                 except:
@@ -259,7 +259,7 @@ class SuperVectorizer(ColumnTransformer):
 
         # If the DataFrame does not have named columns already,
         # apply the learnt columns
-        if X.columns.dtype == "int64":
+        if pd.api.types.is_numeric_dtype(X.columns):
             X.columns = self.columns_
 
         for col in self.imputed_columns_:

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -198,7 +198,9 @@ class SuperVectorizer(ColumnTransformer):
                 if pd.api.types.is_numeric_dtype(X[col]):
                     X[col] = X[col].astype(np.float64)
                 X[col].fillna(value=np.nan, inplace=True)
-        X = X.replace(list(pd.io.parsers.STR_NA_VALUES) + [None, "?", "..."],
+        STR_NA_VALUES = ['null', '', '1.#QNAN', '#NA', 'nan', '#N/A N/A', '-1.#QNAN', '<NA>', '-1.#IND', '-nan', 'n/a',
+                         '-NaN', '1.#IND', 'NULL', 'NA', 'N/A', '#N/A', 'NaN'] #taken from pandas
+        X = X.replace(STR_NA_VALUES + [None, "?", "..."],
                       np.nan)
         X = X.replace(r'^\s+$', np.nan, regex=True) # replace whitespace only
 

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -12,7 +12,6 @@ import sklearn
 
 import numpy as np
 import pandas as pd
-from pandas.io.parsers import STR_NA_VALUES
 
 from warnings import warn
 from typing import Union, Optional, List
@@ -199,7 +198,7 @@ class SuperVectorizer(ColumnTransformer):
                 if pd.api.types.is_numeric_dtype(X[col]):
                     X[col] = X[col].astype(np.float64)
                 X[col].fillna(value=np.nan, inplace=True)
-        X = X.replace(list(STR_NA_VALUES) + [None, "?", "..."],
+        X = X.replace(list(pd.io.parsers.STR_NA_VALUES) + [None, "?", "..."],
                       np.nan)
         X = X.replace(r'^\s+$', np.nan, regex=True) # replace whitespace only
 

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -195,7 +195,8 @@ class SuperVectorizer(ColumnTransformer):
 
         parser = pd.io.parsers.TextParser(X,
                                           header=None,
-                                          na_values=[None, " ", "?", "..."])  # additional values to be considered as NA
+                                          na_values=[pd.NA, None, " ", "?", "..."])  # additional values to be considered as NA
+                                                                                     # adding pd.NA is needed  for python3.6 compatibility
         X = parser.read()
 
         for col in X.columns:

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -18,6 +18,17 @@ def check_same_transformers(expected_transformers: dict, actual_transformers: li
     actual_transformers_dict = dict([(name, cols) for name, trans, cols in actual_transformers])
     assert actual_transformers_dict == expected_transformers
 
+def type_equality(expected_type, actual_type):
+    """
+    Checks that the expected type is equal to the actual type, assuming object and str types
+    are equivalent (considered as categorical by the supervectorizer).
+    """
+    if (isinstance(expected_type , object) or  isinstance(expected_type, str))\
+            and (isinstance(actual_type, object) or isinstance(actual_type, str)):
+        return True
+    else:
+        return expected_type == actual_type
+
 
 def _get_clean_dataframe():
     """
@@ -278,7 +289,7 @@ def test_auto_cast():
     X = _get_clean_dataframe()
     X_trans = vectorizer._auto_cast(X)
     for col in X_trans.columns:
-        assert expected_types_clean_dataframe[col] == X_trans[col].dtype
+        assert type_equality(expected_types_clean_dataframe[col], X_trans[col].dtype)
 
     # Test that missing values don't prevent type detection
     expected_types_dirty_dataframe = {
@@ -293,18 +304,7 @@ def test_auto_cast():
     X = _get_dirty_dataframe()
     X_trans = vectorizer._auto_cast(X)
     for col in X_trans.columns:
-        assert expected_types_dirty_dataframe[col] == X_trans[col].dtype
-
-    X = _get_numpy_array()
-    X_trans = vectorizer._auto_cast(X)
-    for i in range(X_trans.shape[1]):
-        assert list(expected_types_dirty_dataframe.values())[i] == X_trans[i].dtype
-
-    X = _get_list_of_lists()
-    X_trans = vectorizer._auto_cast(X)
-    for i in range(X_trans.shape[1]):
-        assert list(expected_types_dirty_dataframe.values())[i] == X_trans[i].dtype
-
+        assert type_equality(expected_types_dirty_dataframe[col], X_trans[col].dtype)
 
 def test_with_arrays():
     """

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -96,16 +96,6 @@ def _get_datetimes_dataframe():
                       "2014/12/31 23:31:23",
                       "2015/12/31 01:31:34",
                       "2014/01/31 00:32:45"],
-        "y_int": [2005,
-                  1976,
-                  2012,
-                  2001,
-                  2024],
-        "y_int_old": [678,
-                      976,
-                      2012,
-                      2001,
-                      1998]
     })
 
 
@@ -269,8 +259,6 @@ def test_auto_cast():
         "dmy-": "datetime64[ns]",
         "ymd/": "datetime64[ns]",
         "ymd/_hms:": "datetime64[ns]",
-        "y_int": "datetime64[ns]",
-        "y_int_old": "int64",
     }
     X_trans = vectorizer._auto_cast(X)
     for col in X_trans.columns:

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -250,7 +250,7 @@ def test_transform():
     assert (x_trans == [[1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 34, 5.5]]).all()
 
 
-def fit_transform_equiv():
+def test_fit_transform_equiv():
     """
     We will test the equivalence between using `.fit_transform(X)`
     and `.fit(X).transform(X).`
@@ -290,7 +290,7 @@ if __name__ == '__main__':
     test_fit()
     print('test_fit passed')
     print('start fit_transform_equiv')
-    fit_transform_equiv()
+    test_fit_transform_equiv()
     print('fit_transform_equiv passed')
 
     print('Done')

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -405,9 +405,9 @@ def test_fit_transform_equiv():
     enc1_x2 = sup_vec3.fit_transform(X2)
     enc2_x2 = sup_vec4.fit(X2).transform(X2)
 
-    assert np.array_equal(enc1_x1, enc2_x1, equal_nan=True)
+    assert np.allclose(enc1_x1, enc2_x1, rtol=0, atol=0, equal_nan=True)
 
-    assert np.array_equal(enc1_x2, enc2_x2, equal_nan=True)
+    assert np.allclose(enc1_x2, enc2_x2, rtol=0, atol=0, equal_nan=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Uses pandas [`TextParser`](https://github.com/pandas-dev/pandas/blob/06d230151e6f18fdb8139d09abf539867a8cd481/pandas/io/parsers/readers.py#L1289) (used in `read_csv`, as per @GaelVaroquaux suggestion in #234) instead of `convert_dtypes` in the SuperVectorizer `_auto_cast` method. This has several advantages:

- Type detection works on string columns, e.g `["3", "2", "1"]` would get detected as integer. Solves #234 
-  Missing values encoded as strings get treated as missing values, and don't prevent type detection. For instance,` [1, 2, "", 4]` is detected as integers. (solves  #231). Which strings get detected as Nans is easy to change (see below).
- Datetime columns are converted to datetimes, and the format is inferred by Pandas. Solve the first part of #233.

Some comments:
- TODO: I'd like to enable the user to specify a specific date format if he wants to.
- Strings detected as NaNs are the default [`STR_NA_VALUES`](https://github.com/pandas-dev/pandas/blob/main/pandas/_libs/parsers.pyx#L1350), and I've added `[None, " ", "?", "..."]`. I think we could find a more principled way to choose which strings to include.
- I haven't properly measured the speed of the conversion.
- To use TextParser, I need to convert the input data into a list of list. I don't think this is a problem, but tell me if you think otherwise.
- All variables which are not numerics or datetimes are converted to object (and thus handled as categorical in the SuperVectorizer).
- Right now, if a datetime column contains mixed timezones, it is encoded as an object.