### PR TITLE
Doc threshold

### DIFF
--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -109,12 +109,40 @@ class SuperVectorizer(ColumnTransformer):
         When imputed, missing values are replaced by the string 'missing'.
         See also attribute `imputed_columns_`.
         
+    remainder : {'drop', 'passthrough'} or estimator, default='drop'
+        By default, only the specified columns in `transformers` are
+        transformed and combined in the output, and the non-specified
+        columns are dropped. (default of ``'drop'``).
+        By specifying ``remainder='passthrough'``, all remaining columns that
+        were not specified in `transformers` will be automatically passed
+        through. This subset of columns is concatenated with the output of
+        the transformers.
+        By setting ``remainder`` to be an estimator, the remaining
+        non-specified columns will use the ``remainder`` estimator. The
+        estimator must support :term:`fit` and :term:`transform`.
+        Note that using this feature requires that the DataFrame columns
+        input at :term:`fit` and :term:`transform` have identical order.
+        
     sparse_threshold: float, default=0.3
         If the output of the different transformers contains sparse matrices,
         these will be stacked as a sparse matrix if the overall density is
         lower than this value. Use sparse_threshold=0 to always return dense. 
         When the transformed output consists of all dense data, the stacked result
         will be dense, and this keyword will be ignored.
+        
+    n_jobs : int, default=None
+        Number of jobs to run in parallel.
+        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
+        ``-1`` means using all processors.
+        
+    transformer_weights : dict, default=None
+        Multiplicative weights for features per transformer. The output of the
+        transformer is multiplied by these weights. Keys are transformer names,
+        values the weights.
+        
+    verbose : bool, default=False
+        If True, the time elapsed while fitting each transformer will be
+        printed as it is completed
 
     Attributes
     ----------

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -116,7 +116,6 @@ class SuperVectorizer(ColumnTransformer):
         When the transformed output consists of all dense data, the stacked result
         will be dense, and this keyword will be ignored.
 
-
     Attributes
     ----------
 

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -108,6 +108,14 @@ class SuperVectorizer(ColumnTransformer):
         'skip' will not impute at all.
         When imputed, missing values are replaced by the string 'missing'.
         See also attribute `imputed_columns_`.
+        
+    sparse_threshold: float, default=0.3
+        If the output of the different transformers contains sparse matrices,
+        these will be stacked as a sparse matrix if the overall density is
+        lower than this value. Use sparse_threshold=0 to always return dense. 
+        When the transformed output consists of all dense data, the stacked result
+        will be dense, and this keyword will be ignored.
+
 
     Attributes
     ----------


### PR DESCRIPTION
Following our discussion in #244.

I added text in the docs of the SuperVectorizer, to explain the meaning of the sparse_threshold parameter. 
As agreed, I just copied the same from the [Column Transformer](https://scikit-learn.org/stable/modules/generated/sklearn.compose.ColumnTransformer.html).

Thanks.