### PR TITLE
Fix logic to allow all iterables (not only lists)

### DIFF
--- a/dirty_cat/gap_encoder.py
+++ b/dirty_cat/gap_encoder.py
@@ -744,15 +744,15 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         assert hasattr(self, 'fitted_models_'), (
             'ERROR: GapEncoder must be fitted first.')
         # Generate prefixes
-        if isinstance(col_names, list):
-            prefixes = [s + ': ' for s in col_names]
-        elif col_names == 'auto':
+        if isinstance(col_names, str) and col_names == 'auto':
             if hasattr(self, 'column_names_'): # Use column names
                 prefixes = [s + ': ' for s in self.column_names_]
             else: # Use 'col1: ', ... 'colN: ' as prefixes
                 prefixes = [f'col{k}: ' for k in range(len(self.fitted_models_))]
-        else: # Empty prefixes
+        elif col_names is None:  # Empty prefixes
             prefixes = [''] * len(self.fitted_models_)
+        else:
+            prefixes = [s + ': ' for s in col_names]
         labels = list()
         for k, enc in enumerate(self.fitted_models_):
             col_labels = enc.get_feature_names_out(n_labels, prefixes[k])


### PR DESCRIPTION
This fixes an issue in the notebook, as seen here:

```
Traceback (most recent call last):
  File "/home/circleci/project/examples/01_dirty_categories.py", line 321, in <module>
    feature_names = sup_vec.get_feature_names()
  File "/home/circleci/project/dirty_cat/super_vectorizer.py", line 488, in get_feature_names
    return self.get_feature_names_out()
  File "/home/circleci/project/dirty_cat/super_vectorizer.py", line 456, in get_feature_names_out
    ct_feature_names = super().get_feature_names_out()
  File "/home/circleci/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/compose/_column_transformer.py", line 479, in get_feature_names_out
    feature_names_out = self._get_feature_name_out_for_transformer(
  File "/home/circleci/miniconda/envs/testenv/lib/python3.8/site-packages/sklearn/compose/_column_transformer.py", line 451, in _get_feature_name_out_for_transformer
    return trans.get_feature_names_out(names)
  File "/home/circleci/project/dirty_cat/gap_encoder.py", line 749, in get_feature_names_out
    elif col_names == 'auto':
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

it's a simple fix really, just reorganizing the logic so that not only lists are supported, but iterables in general.