### PR TITLE
Fix SuperVectorizer's `get_feature_names_out` `FutureWarning`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Bug-fixes
 ---------
 
 * Fixed a bug in the :class:`SuperVectorizer` causing a `FutureWarning`
-  when using the `get_feature_names` method.
+  when using the `get_feature_names_out` method.
 
 Release 0.2.1
 =============

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Release 0.2.2
+=============
+
+Bug-fixes
+---------
+
+* Fixed a bug in the :class:`SuperVectorizer` causing a `FutureWarning`
+  when using the `get_feature_names` method.
+
 Release 0.2.1
 =============
 

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -468,7 +468,10 @@ class SuperVectorizer(ColumnTransformer):
             if not hasattr(trans, 'get_feature_names'):
                 all_trans_feature_names.extend(cols)
             else:
-                trans_feature_names = trans.get_feature_names(cols)
+                if _sklearn_loose_version < LooseVersion('1.0'):
+                    trans_feature_names = trans.get_feature_names(cols)
+                else:
+                    trans_feature_names = trans.get_feature_names_out(cols)
                 all_trans_feature_names.extend(trans_feature_names)
 
         if len(ct_feature_names) != len(all_trans_feature_names):


### PR DESCRIPTION
Continuation of #216 
Fixes #259 by performing the same version check as the other occurrences.