### PR TITLE
Add introductory video on the website

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,6 +49,10 @@ pipeline you can tweak.
     </div>
     </div>
 
+.. raw:: html
+
+    <iframe src="https://youtu.be/_GNaaeEI2tg" frameborder="0" allowfullscreen></iframe>
+
 For a detailed description of the problem of encoding dirty categorical data,
 see `Similarity encoding for learning with dirty categorical variables
 <https://hal.inria.fr/hal-01806175>`_ [1]_ and `Encoding high-cardinality

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,7 +51,11 @@ pipeline you can tweak.
 
 .. raw:: html
 
-    <iframe src="https://youtu.be/_GNaaeEI2tg" frameborder="0" allowfullscreen></iframe>
+    <iframe width="560" height="315"
+     src="https://www.youtube-nocookie.com/embed/_GNaaeEI2tg" frameborder="0"
+     allow="accelerometer; autoplay; clipboard-write;
+     encrypted-media; gyroscope; picture-in-picture" allowfullscreen
+    ></iframe>
 
 For a detailed description of the problem of encoding dirty categorical data,
 see `Similarity encoding for learning with dirty categorical variables

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -49,7 +49,7 @@ pipeline you can tweak.
     </div>
     </div>
     <div class="flex-container">
-    <div class="flex-content">
+    <div class="flex-content" style="border: 0px;">
 
 For a detailed description of the problem of encoding dirty categorical data,
 see `Similarity encoding for learning with dirty categorical variables
@@ -59,7 +59,7 @@ string categorical variables <https://hal.inria.fr/hal-02171256v4>`_ [2]_.
 .. raw:: html
 
     </div>
-    <div class="flex-content">
+    <div class="flex-content" style="border: 0px;">
     <iframe style="display: block; margin: auto; width: 100%;" width="560" height="315"
      src="https://www.youtube.com/embed/_GNaaeEI2tg" frameborder="0"
      allow="accelerometer; autoplay; clipboard-write;

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,20 +51,20 @@ pipeline you can tweak.
     <div class="flex-container">
     <div class="flex-content">
 
-.. raw:: html
-
-    <iframe style="display: block; margin: auto;" width="560" height="315"
-     src="https://www.youtube.com/embed/_GNaaeEI2tg" frameborder="0"
-     allow="accelerometer; autoplay; clipboard-write;
-     encrypted-media; gyroscope; picture-in-picture" allowfullscreen
-    ></iframe>
-    </div>
-    <div class="flex-content">
-
 For a detailed description of the problem of encoding dirty categorical data,
 see `Similarity encoding for learning with dirty categorical variables
 <https://hal.inria.fr/hal-01806175>`_ [1]_ and `Encoding high-cardinality
 string categorical variables <https://hal.inria.fr/hal-02171256v4>`_ [2]_.
+
+.. raw:: html
+
+    </div>
+    <div class="flex-content">
+    <iframe style="display: block; margin: auto; width: 100%;"
+     src="https://www.youtube.com/embed/_GNaaeEI2tg" frameborder="0"
+     allow="accelerometer; autoplay; clipboard-write;
+     encrypted-media; gyroscope; picture-in-picture" allowfullscreen
+    ></iframe>
 
 .. raw:: html
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,8 +51,8 @@ pipeline you can tweak.
 
 .. raw:: html
 
-    <iframe width="560" height="315"
-     src="https://www.youtube-nocookie.com/embed/_GNaaeEI2tg" frameborder="0"
+    <iframe style="display: block; margin: auto;" width="560" height="315"
+     src="https://www.youtube.com/embed/_GNaaeEI2tg" frameborder="0"
      allow="accelerometer; autoplay; clipboard-write;
      encrypted-media; gyroscope; picture-in-picture" allowfullscreen
     ></iframe>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,7 +60,7 @@ string categorical variables <https://hal.inria.fr/hal-02171256v4>`_ [2]_.
 
     </div>
     <div class="flex-content">
-    <iframe style="display: block; margin: auto; width: 100%;"
+    <iframe style="display: block; margin: auto; width: 100%;" width="560" height="315"
      src="https://www.youtube.com/embed/_GNaaeEI2tg" frameborder="0"
      allow="accelerometer; autoplay; clipboard-write;
      encrypted-media; gyroscope; picture-in-picture" allowfullscreen

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -48,6 +48,8 @@ pipeline you can tweak.
 
     </div>
     </div>
+    <div class="flex-container">
+    <div class="flex-content">
 
 .. raw:: html
 
@@ -56,11 +58,18 @@ pipeline you can tweak.
      allow="accelerometer; autoplay; clipboard-write;
      encrypted-media; gyroscope; picture-in-picture" allowfullscreen
     ></iframe>
+    </div>
+    <div class="flex-content">
 
 For a detailed description of the problem of encoding dirty categorical data,
 see `Similarity encoding for learning with dirty categorical variables
 <https://hal.inria.fr/hal-01806175>`_ [1]_ and `Encoding high-cardinality
 string categorical variables <https://hal.inria.fr/hal-02171256v4>`_ [2]_.
+
+.. raw:: html
+
+    </div>
+    </div>
 
 .. rst-class:: right-align
 


### PR DESCRIPTION
For a congress I recently participated in, I realized a video presenting some encoders implemented in dirty_cat.
The video [is available on YouTube](https://youtu.be/_GNaaeEI2tg) and I though we could add it to the website if you think this is relevant :)