### PR TITLE
Display column names instead of indices for remainder columns in the transformers_ attribute of the SuperVectorizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Release 0.3.0
+=============
+
+Notes
+-----
+
+* The transformers_ attribute of the SuperVectorizer now contains column names
+instead of column indices for the "remainder" columns.
+
 Release 0.2.1
 =============
 

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -430,10 +430,11 @@ class SuperVectorizer(ColumnTransformer):
         res = super().fit_transform(X, y)
 
         # for the "remainder" columns, the ColumnTransformer transformers_ attribute
-        # contains the index instead of the column name so we convert it to the column name.
+        # contains the index instead of the column name, so we convert it to the column name
+        # if there is less than 20 columns in the remainder.
         for i, tup in enumerate(self.transformers_):
             name, enc, cols = tup  # Unpack
-            if name == "remainder":
+            if name == "remainder" and len(cols) < 20:
                 self.transformers_[i] = (name, enc, [self.columns_[j] for j in cols])
 
         return res

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -427,7 +427,16 @@ class SuperVectorizer(ColumnTransformer):
         if self.verbose:
             print(f'[SuperVectorizer] Assigned transformers: {self.transformers}')
 
-        return super().fit_transform(X, y)
+        res = super().fit_transform(X, y)
+
+        # for the "remainder" columns, the ColumnTransformer transformers_ attribute
+        # contains the index instead of the column name so we convert it to the column name.
+        for i, tup in enumerate(self.transformers_):
+            name, enc, cols = tup  # Unpack
+            if name == "remainder":
+                self.transformers_[i] = (name, enc, [self.columns_[j] for j in cols])
+
+        return res
 
     def get_feature_names_out(self, input_features=None) -> List[str]:
         """


### PR DESCRIPTION
Solves #232 
Following discussion with @GaelVaroquaux in previous PR (#236), I've made the modification in the fit method of the SuperVectorizer.