### PR TITLE
Adapt the `SimilarityEncoder` to use `get_feature_names_out`

### DIFF
--- a/dirty_cat/similarity_encoder.py
+++ b/dirty_cat/similarity_encoder.py
@@ -326,6 +326,7 @@ class SimilarityEncoder(OneHotEncoder):
                     X[mask] = self.handle_missing
 
         Xlist, n_samples, n_features = self._check_X(X)
+        self.n_features_in_ = n_features
 
         if self.handle_unknown not in ['error', 'ignore']:
             template = ("handle_unknown should be either 'error' or "


### PR DESCRIPTION
I was fixing up some tests as part of #277, and they failed when using `get_feature_names_out` on the `SimilarityEncoder`.

After a bit of digging, this is due to a missing variable `n_features_in_`, that is [set in the `_fit` method](https://github.com/scikit-learn/scikit-learn/blob/8a8d0687eed25481db39aa5c5b85148b2933d0a7/sklearn/preprocessing/_encoders.py#L86) of the `_BaseEncoder` (from which the `OneHotEncoder`, and therefore, the `SimilarityEncoder` inherit).
We don't use this method, which is why it's not set.