### PR TITLE
Bump scipy & numpy versions to fix the slow CI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Major changes
     columns (year, month, day, hour, minute, second, ...). It is now the default transformer used
     in the SuperVectorizer for datetime columns.
 * Support for Python 3.6 and 3.7 has been dropped. Python >= 3.8 is now required.
+* Bumped minimum dependencies:
+  - scipy>=1.4.0
+  - numpy>=1.17.3
 
 Notes
 -----

--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,8 @@ Dependencies
 dirty_cat requires:
 
 - Python (>= 3.8)
-- NumPy (>= 1.16)
-- SciPy (>= 1.2)
+- NumPy (>= 1.17.3)
+- SciPy (>= 1.4.0)
 - scikit-learn (>= 0.21.0)
 - pandas (>= 1.1.5)
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,5 @@
-numpy==1.16
-scipy==1.2
+numpy==1.17.3
+scipy==1.4.0
 scikit-learn==0.22.0
 pytest
 pytest-cov


### PR DESCRIPTION
This is a change extracted from #287: it aims at fixing the very slow CI for the minimal dependencies worker.
As these changes were already discussed over there, and this is an issue we have on all PRs right now, I'll merge these changes right away.