### PR TITLE
Fetching: move `namedtuples` to `dataclasses`, and add target name to `DatasetInfoOnly`

### DIFF
--- a/dirty_cat/datasets/fetching.py
+++ b/dirty_cat/datasets/fetching.py
@@ -69,6 +69,7 @@ class Features:
 
 @dataclass(unsafe_hash=True)
 class DatasetAll:
+    name: str
     description: str
     X: pd.DataFrame
     y: pd.Series
@@ -78,6 +79,7 @@ class DatasetAll:
 
 @dataclass(unsafe_hash=True)
 class DatasetInfoOnly:
+    name: str
     description: str
     source: str
     target: str
@@ -320,7 +322,9 @@ def _features_to_csv_format(features: Features) -> str:
     return ",".join(features.names)
 
 
-def fetch_dataset_as_dataclass(dataset_id: int, target: str,
+def fetch_dataset_as_dataclass(dataset_name: str,
+                               dataset_id: int,
+                               target: str,
                                read_csv_kwargs: dict,
                                load_dataframe: bool,
                                ) -> Union[DatasetAll, DatasetInfoOnly]:
@@ -346,6 +350,7 @@ def fetch_dataset_as_dataclass(dataset_id: int, target: str,
         y = df[target]
         X = df.drop(target, axis='columns')
         dataset = DatasetAll(
+            name=dataset_name,
             description=info['description'],
             X=X,
             y=y,
@@ -354,6 +359,7 @@ def fetch_dataset_as_dataclass(dataset_id: int, target: str,
         )
     else:
         dataset = DatasetInfoOnly(
+            name=dataset_name,
             description=info['description'],
             source=info['source'],
             target=target,
@@ -399,6 +405,7 @@ def fetch_employee_salaries(load_dataframe: bool = True,
         If `load_dataframe=False`
     """
     dataset = fetch_dataset_as_dataclass(
+        dataset_name='Employee salaries',
         dataset_id=EMPLOYEE_SALARIES_ID,
         target='current_annual_salary',
         read_csv_kwargs={
@@ -438,6 +445,7 @@ def fetch_road_safety(load_dataframe: bool = True,
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
+        dataset_name='Road safety',
         dataset_id=ROAD_SAFETY_ID,
         target='Sex_of_Driver',
         read_csv_kwargs={
@@ -471,6 +479,7 @@ def fetch_medical_charge(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
+        dataset_name='Medical charge',
         dataset_id=MEDICAL_CHARGE_ID,
         target='Average_Total_Payments',
         read_csv_kwargs={
@@ -498,6 +507,7 @@ def fetch_midwest_survey(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
+        dataset_name='Midwest survey',
         dataset_id=MIDWEST_SURVEY_ID,
         target='Census_Region',
         read_csv_kwargs={
@@ -526,6 +536,7 @@ def fetch_open_payments(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
+        dataset_name='Open payments',
         dataset_id=OPEN_PAYMENTS_ID,
         target='status',
         read_csv_kwargs={
@@ -557,6 +568,7 @@ def fetch_traffic_violations(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
+        dataset_name='Traffic violations',
         dataset_id=TRAFFIC_VIOLATIONS_ID,
         target='violation_type',
         read_csv_kwargs={
@@ -586,6 +598,7 @@ def fetch_drug_directory(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
+        dataset_name='Drug directory',
         dataset_id=DRUG_DIRECTORY_ID,
         target='PRODUCTTYPENAME',
         read_csv_kwargs={

--- a/dirty_cat/datasets/tests/test_fetching.py
+++ b/dirty_cat/datasets/tests/test_fetching.py
@@ -131,10 +131,14 @@ def test_fetch_openml_dataset_mocked(mock_download, mock_export,
     we mock the functions to test its inner mechanisms.
     """
 
-    mock_get_details.return_value = Details("Dataset_name", "123456",
-                                            "Dummy dataset description.")
-    mock_get_features.return_value = Features(["id", "name", "transaction_id",
-                                               "owner", "recipient"])
+    mock_get_details.return_value = Details(
+        name="Dataset_name",
+        file_id="123456",
+        description="Dummy dataset description."
+    )
+    mock_get_features.return_value = Features(
+        names=["id", "name", "transaction_id", "owner", "recipient"]
+    )
 
     test_data_dir = get_test_data_dir()
 
@@ -296,14 +300,15 @@ def test__features_to_csv_format():
 
 
 @mock.patch('dirty_cat.datasets.fetching.fetch_openml_dataset')
-@mock.patch("dirty_cat.datasets.fetching.fetch_dataset_as_namedtuple")
-def test_import_all_datasets(mock_fetch_dataset_as_namedtuple,
+@mock.patch("dirty_cat.datasets.fetching.fetch_dataset_as_dataclass")
+def test_import_all_datasets(mock_fetch_dataset_as_dataclass,
                              mock_fetch_openml_dataset):
     """Tests functions ``fetch_*()``."""
 
     mock_fetch_openml_dataset.return_value = {
         'description': 'This is a dataset.',
         'source': 'https://www.openml.org/',
+        'target': 'To_predict',
         'path': Path("/path/to/file.csv"),
         'read_csv_kwargs': {'a': 'b'},
     }
@@ -319,6 +324,7 @@ def test_import_all_datasets(mock_fetch_dataset_as_namedtuple,
     expected_return_value_info_only = fetching.DatasetInfoOnly(
         description="This is a dataset.",
         source="https://www.openml.org/",
+        target='To_predict',
         path=Path("/path/to/file.csv"),
         read_csv_kwargs={'a': 'b'},
     )
@@ -327,7 +333,7 @@ def test_import_all_datasets(mock_fetch_dataset_as_namedtuple,
         [expected_return_value_all, expected_return_value_info_only],
         [True, False],
     ):
-        mock_fetch_dataset_as_namedtuple.return_value = expected_return_value
+        mock_fetch_dataset_as_dataclass.return_value = expected_return_value
 
         returned_value = fetching.fetch_employee_salaries(drop_linked=False,
                                                           drop_irrelevant=False)

--- a/dirty_cat/datasets/tests/test_fetching.py
+++ b/dirty_cat/datasets/tests/test_fetching.py
@@ -306,6 +306,7 @@ def test_import_all_datasets(mock_fetch_dataset_as_dataclass,
     """Tests functions ``fetch_*()``."""
 
     mock_fetch_openml_dataset.return_value = {
+        'name': 'Example dataset',
         'description': 'This is a dataset.',
         'source': 'https://www.openml.org/',
         'target': 'To_predict',
@@ -314,6 +315,7 @@ def test_import_all_datasets(mock_fetch_dataset_as_dataclass,
     }
 
     expected_return_value_all = fetching.DatasetAll(
+        name='Example dataset',
         description="This is a dataset.",
         source="https://www.openml.org/",
         path=Path("/path/to/file.csv"),
@@ -322,6 +324,7 @@ def test_import_all_datasets(mock_fetch_dataset_as_dataclass,
     )
 
     expected_return_value_info_only = fetching.DatasetInfoOnly(
+        name='Example dataset',
         description="This is a dataset.",
         source="https://www.openml.org/",
         target='To_predict',


### PR DESCRIPTION
Trying to use the no-loading version of the fetchers, I realized we're not passing the target name, and it's annoying to hard-code in downstream code, so I've added it to the `DatasetInfoOnly` requirements.
Also, since we're now in Python 3.8+ territory, I've figured we should use dataclasses instead of namedtuples, as their syntax is a little nicer (though more verbose), but most importantly, they integrate type hinting !