### PR TITLE
DEV Add a simple `pre-commit` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+        types: [file, python]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+     -  id: mypy
+        files: dirty_cat/
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
+        files: dirty_cat/
+        args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,16 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
         types: [file, python]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v0.971
     hooks:
      -  id: mypy
         files: dirty_cat/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 80
+line-length = 88
 target_version = ['py38', 'py39', 'py310']
 preview = true
 # Exclude irrelevant directories for formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 80
+target_version = ['py38', 'py39', 'py310']
+preview = true
+# Exclude irrelevant directories for formatting
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.mypy_cache
+  | \.vscode
+  | \.pytest_cache
+  | \.idea
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 # max line length for black
-max-line-length = 80
+max-line-length = 88
 target-version = ['py310']
 # Default flake8 3.5 ignored flags
 ignore=

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[flake8]
+# max line length for black
+max-line-length = 80
+target-version = ['py310']
+# Default flake8 3.5 ignored flags
+ignore=
+    E24,   # check ignored by default in flake8. Meaning unclear.
+    E121,  # continuation line under-indented
+    E123,  # closing bracket does not match indentation
+    E126,  # continuation line over-indented for hanging indent
+    E203,  # space before : (needed for how black formats slicing)
+    E226,  # missing whitespace around arithmetic operator
+    E704,  # multiple statements on one line (def)
+    E731,  # do not assign a lambda expression, use a def
+    E741,  # do not use variables named 'l', 'O', or 'I'
+    W503,  # line break before binary operator
+    W504   # line break after binary operator
+exclude=
+    .git,
+    __pycache__,
+    dist,
+    build
+
+
+[mypy]
+ignore_missing_imports = True
+allow_redefinition = True
+
+[codespell]
+skip = ./.git,./.mypy_cache


### PR DESCRIPTION
Fixes https://github.com/dirty-cat/dirty_cat/issues/304.

This adds a simple pre-commit setup with `black`, `flake8`, `isort` and `mypy`.

Note that the code-base needs to be formatted using this setup.
IMO, this might better be done in another PR with a single commit to better ignore formatting changes (see [this blog](https://michaelheap.com/git-ignore-rev/) post for introduction).

Also, a GitHub action workflow can then be introduced to check that changes made in Pull Requests comply with this setup.