### PR TITLE
MAINT Format the code-base to be `pre-commit` compliant

### DIFF
--- a/dirty_cat/__init__.py
+++ b/dirty_cat/__init__.py
@@ -3,17 +3,22 @@ dirty_cat: Learning on dirty categories.
 """
 import os
 
-version_file = os.path.join(os.path.dirname(__file__), 'VERSION.txt')
+from .datetime_encoder import DatetimeEncoder
+from .gap_encoder import GapEncoder
+from .minhash_encoder import MinHashEncoder
+from .similarity_encoder import SimilarityEncoder
+from .super_vectorizer import SuperVectorizer
+from .target_encoder import TargetEncoder
+
+version_file = os.path.join(os.path.dirname(__file__), "VERSION.txt")
 with open(version_file) as fh:
     __version__ = fh.read().strip()
 
-from .similarity_encoder import SimilarityEncoder
-from .target_encoder import TargetEncoder
-from .minhash_encoder import MinHashEncoder
-from .gap_encoder import GapEncoder
-from .datetime_encoder import DatetimeEncoder
-from .super_vectorizer import SuperVectorizer
-
-
-__all__ = ['SimilarityEncoder', 'TargetEncoder', 'MinHashEncoder',
-           'GapEncoder', 'DatetimeEncoder', 'SuperVectorizer']
+__all__ = [
+    "SimilarityEncoder",
+    "TargetEncoder",
+    "MinHashEncoder",
+    "GapEncoder",
+    "DatetimeEncoder",
+    "SuperVectorizer",
+]

--- a/dirty_cat/datasets/__init__.py
+++ b/dirty_cat/datasets/__init__.py
@@ -1,19 +1,21 @@
-from .fetching import get_data_dir
-from .fetching import fetch_medical_charge
-from .fetching import fetch_midwest_survey
-from .fetching import fetch_employee_salaries
-from .fetching import fetch_road_safety
-from .fetching import fetch_open_payments
-from .fetching import fetch_drug_directory
-from .fetching import fetch_traffic_violations
+from .fetching import (
+    fetch_drug_directory,
+    fetch_employee_salaries,
+    fetch_medical_charge,
+    fetch_midwest_survey,
+    fetch_open_payments,
+    fetch_road_safety,
+    fetch_traffic_violations,
+    get_data_dir,
+)
 
 __all__ = [
-    'get_data_dir',
-    'fetch_medical_charge',
-    'fetch_midwest_survey',
-    'fetch_employee_salaries',
-    'fetch_road_safety',
-    'fetch_open_payments',
-    'fetch_drug_directory',
-    'fetch_traffic_violations'
+    "get_data_dir",
+    "fetch_medical_charge",
+    "fetch_midwest_survey",
+    "fetch_employee_salaries",
+    "fetch_road_safety",
+    "fetch_open_payments",
+    "fetch_drug_directory",
+    "fetch_traffic_violations",
 ]

--- a/dirty_cat/datasets/fetching.py
+++ b/dirty_cat/datasets/fetching.py
@@ -11,11 +11,11 @@ Scikit-Learn's ``fetch_openml()`` function.
 import gzip
 import json
 import warnings
-import pandas as pd
-
-from pathlib import Path
 from dataclasses import dataclass
-from typing import Union, Dict, Any, List
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import pandas as pd
 from sklearn.datasets import fetch_openml
 
 from dirty_cat.datasets.utils import get_data_dir
@@ -79,9 +79,10 @@ class DatasetInfoOnly:
     read_csv_kwargs: Dict[str, Any]
 
 
-def fetch_openml_dataset(dataset_id: int,
-                         data_directory: Path = get_data_dir(),
-                         ) -> Dict[str, Any]:
+def fetch_openml_dataset(
+    dataset_id: int,
+    data_directory: Path = get_data_dir(),
+) -> Dict[str, Any]:
     """
     Gets a dataset from OpenML (https://www.openml.org),
     or from the disk if already downloaded.
@@ -112,8 +113,8 @@ def fetch_openml_dataset(dataset_id: int,
     data_directory = data_directory.resolve()
 
     # Construct the path to the gzip file containing the details on a dataset.
-    details_gz_path = data_directory / DETAILS_DIRECTORY / f'{dataset_id}.gz'
-    features_gz_path = data_directory / FEATURES_DIRECTORY / f'{dataset_id}.gz'
+    details_gz_path = data_directory / DETAILS_DIRECTORY / f"{dataset_id}.gz"
+    features_gz_path = data_directory / FEATURES_DIRECTORY / f"{dataset_id}.gz"
 
     if not details_gz_path.is_file() or not features_gz_path.is_file():
         # If the details file or the features file don't exist,
@@ -127,22 +128,24 @@ def fetch_openml_dataset(dataset_id: int,
             UserWarning,
             stacklevel=2,
         )
-        _download_and_write_openml_dataset(dataset_id=dataset_id,
-                                           data_directory=data_directory)
+        _download_and_write_openml_dataset(
+            dataset_id=dataset_id, data_directory=data_directory
+        )
     details = _get_details(details_gz_path)
 
     # The file ID is required because the data file is named after this ID,
     # and not after the dataset's.
     file_id = details.file_id
-    csv_path = data_directory / f'{details.name}.csv'
+    csv_path = data_directory / f"{details.name}.csv"
 
-    data_gz_path = data_directory / DATA_DIRECTORY / f'{file_id}.gz'
+    data_gz_path = data_directory / DATA_DIRECTORY / f"{file_id}.gz"
 
     if not data_gz_path.is_file():
         # double-check.
         # If the data file does not exist, download the dataset.
-        _download_and_write_openml_dataset(dataset_id=dataset_id,
-                                           data_directory=data_directory)
+        _download_and_write_openml_dataset(
+            dataset_id=dataset_id, data_directory=data_directory
+        )
 
     if not csv_path.is_file():
         # If the CSV file does not exist, use the dataset
@@ -155,12 +158,11 @@ def fetch_openml_dataset(dataset_id: int,
     return {
         "description": details.description,
         "source": url,
-        "path": csv_path.resolve()
+        "path": csv_path.resolve(),
     }
 
 
-def _download_and_write_openml_dataset(dataset_id: int,
-                                       data_directory: Path) -> None:
+def _download_and_write_openml_dataset(dataset_id: int, data_directory: Path) -> None:
     """
     Downloads a dataset from OpenML,
     taking care of creating the directories.
@@ -212,7 +214,7 @@ def _read_json_from_gz(compressed_dir_path: Path) -> dict:
         raise FileNotFoundError(f"Couldn't find file {compressed_dir_path!s}")
 
     # Read content
-    with gzip.open(compressed_dir_path, mode='rt') as gz:
+    with gzip.open(compressed_dir_path, mode="rt") as gz:
         content = gz.read()
 
     details_json = json.JSONDecoder().decode(content)
@@ -265,13 +267,12 @@ def _get_features(compressed_dir_path: Path) -> Features:
     # We filter out the irrelevant information.
     # If you want to modify this list (to add or remove items)
     # you must also modify the ``Features`` object definition.
-    return Features(
-        names=[column["name"] for column in raw_features["feature"]]
-    )
+    return Features(names=[column["name"] for column in raw_features["feature"]])
 
 
-def _export_gz_data_to_csv(compressed_dir_path: Path,
-                           destination_file: Path, features: Features) -> None:
+def _export_gz_data_to_csv(
+    compressed_dir_path: Path, destination_file: Path, features: Features
+) -> None:
     """
     Reads a gzip file containing ARFF data,
     and writes it to a target CSV.
@@ -287,8 +288,8 @@ def _export_gz_data_to_csv(compressed_dir_path: Path,
 
     """
     atdata_found = False
-    with destination_file.open(mode="w", encoding='utf8') as csv:
-        with gzip.open(compressed_dir_path, mode="rt", encoding='utf8') as gz:
+    with destination_file.open(mode="w", encoding="utf8") as csv:
+        with gzip.open(compressed_dir_path, mode="rt", encoding="utf8") as gz:
             csv.write(_features_to_csv_format(features))
             csv.write("\n")
             # We will look at each line of the file until we find
@@ -305,12 +306,13 @@ def _features_to_csv_format(features: Features) -> str:
     return ",".join(features.names)
 
 
-def fetch_dataset_as_dataclass(dataset_name: str,
-                               dataset_id: int,
-                               target: str,
-                               read_csv_kwargs: dict,
-                               load_dataframe: bool,
-                               ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_dataset_as_dataclass(
+    dataset_name: str,
+    dataset_id: int,
+    target: str,
+    read_csv_kwargs: dict,
+    load_dataframe: bool,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """
     Takes a dataset identifier, a target column name,
     and some additional keyword arguments for `pd.read_csv`.
@@ -329,24 +331,24 @@ def fetch_dataset_as_dataclass(dataset_name: str,
     """
     info = fetch_openml_dataset(dataset_id)
     if load_dataframe:
-        df = pd.read_csv(info['path'], **read_csv_kwargs)
+        df = pd.read_csv(info["path"], **read_csv_kwargs)
         y = df[target]
-        X = df.drop(target, axis='columns')
+        X = df.drop(target, axis="columns")
         dataset = DatasetAll(
             name=dataset_name,
-            description=info['description'],
+            description=info["description"],
             X=X,
             y=y,
-            source=info['source'],
-            path=info['path'],
+            source=info["source"],
+            path=info["path"],
         )
     else:
         dataset = DatasetInfoOnly(
             name=dataset_name,
-            description=info['description'],
-            source=info['source'],
+            description=info["description"],
+            source=info["source"],
             target=target,
-            path=info['path'],
+            path=info["path"],
             read_csv_kwargs=read_csv_kwargs,
         )
 
@@ -357,10 +359,11 @@ def fetch_dataset_as_dataclass(dataset_name: str,
 # Public API
 
 
-def fetch_employee_salaries(load_dataframe: bool = True,
-                            drop_linked: bool = True,
-                            drop_irrelevant: bool = True,
-                            ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_employee_salaries(
+    load_dataframe: bool = True,
+    drop_linked: bool = True,
+    drop_irrelevant: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the employee_salaries dataset (regression), available at
     https://openml.org/d/42125
 
@@ -388,28 +391,30 @@ def fetch_employee_salaries(load_dataframe: bool = True,
         If `load_dataframe=False`
     """
     dataset = fetch_dataset_as_dataclass(
-        dataset_name='Employee salaries',
+        dataset_name="Employee salaries",
         dataset_id=EMPLOYEE_SALARIES_ID,
-        target='current_annual_salary',
+        target="current_annual_salary",
         read_csv_kwargs={
-            'quotechar': "'",
-            'escapechar': '\\',
-            'na_values': ['?'],
+            "quotechar": "'",
+            "escapechar": "\\",
+            "na_values": ["?"],
         },
         load_dataframe=load_dataframe,
     )
     if load_dataframe:
         if drop_linked:
-            dataset.X.drop(["2016_gross_pay_received", "2016_overtime_pay"],
-                           axis=1, inplace=True)
+            dataset.X.drop(
+                ["2016_gross_pay_received", "2016_overtime_pay"], axis=1, inplace=True
+            )
         if drop_irrelevant:
             dataset.X.drop(["full_name"], axis=1, inplace=True)
 
     return dataset
 
 
-def fetch_road_safety(load_dataframe: bool = True,
-                      ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_road_safety(
+    load_dataframe: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the road safety dataset (classification), available at
     https://openml.org/d/42803
 
@@ -428,18 +433,19 @@ def fetch_road_safety(load_dataframe: bool = True,
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
-        dataset_name='Road safety',
+        dataset_name="Road safety",
         dataset_id=ROAD_SAFETY_ID,
-        target='Sex_of_Driver',
+        target="Sex_of_Driver",
         read_csv_kwargs={
-            'na_values': ['?'],
+            "na_values": ["?"],
         },
         load_dataframe=load_dataframe,
     )
 
 
-def fetch_medical_charge(load_dataframe: bool = True
-                         ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_medical_charge(
+    load_dataframe: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the medical charge dataset (regression), available at
     https://openml.org/d/42720
 
@@ -462,19 +468,20 @@ def fetch_medical_charge(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
-        dataset_name='Medical charge',
+        dataset_name="Medical charge",
         dataset_id=MEDICAL_CHARGE_ID,
-        target='Average_Total_Payments',
+        target="Average_Total_Payments",
         read_csv_kwargs={
-            'quotechar': "'",
-            'escapechar': '\\',
+            "quotechar": "'",
+            "escapechar": "\\",
         },
         load_dataframe=load_dataframe,
     )
 
 
-def fetch_midwest_survey(load_dataframe: bool = True
-                         ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_midwest_survey(
+    load_dataframe: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the midwest survey dataset (classification), available at
     https://openml.org/d/42805
 
@@ -490,19 +497,20 @@ def fetch_midwest_survey(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
-        dataset_name='Midwest survey',
+        dataset_name="Midwest survey",
         dataset_id=MIDWEST_SURVEY_ID,
-        target='Census_Region',
+        target="Census_Region",
         read_csv_kwargs={
-            'quotechar': "'",
-            'escapechar': '\\',
+            "quotechar": "'",
+            "escapechar": "\\",
         },
         load_dataframe=load_dataframe,
     )
 
 
-def fetch_open_payments(load_dataframe: bool = True
-                        ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_open_payments(
+    load_dataframe: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the open payments dataset (classification), available at
     https://openml.org/d/42738
 
@@ -519,20 +527,21 @@ def fetch_open_payments(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
-        dataset_name='Open payments',
+        dataset_name="Open payments",
         dataset_id=OPEN_PAYMENTS_ID,
-        target='status',
+        target="status",
         read_csv_kwargs={
-            'quotechar': "'",
-            'escapechar': '\\',
-            'na_values': ['?'],
+            "quotechar": "'",
+            "escapechar": "\\",
+            "na_values": ["?"],
         },
         load_dataframe=load_dataframe,
     )
 
 
-def fetch_traffic_violations(load_dataframe: bool = True
-                             ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_traffic_violations(
+    load_dataframe: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the traffic violations dataset (classification), available at
     https://openml.org/d/42132
 
@@ -551,20 +560,21 @@ def fetch_traffic_violations(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
-        dataset_name='Traffic violations',
+        dataset_name="Traffic violations",
         dataset_id=TRAFFIC_VIOLATIONS_ID,
-        target='violation_type',
+        target="violation_type",
         read_csv_kwargs={
-            'quotechar': "'",
-            'escapechar': '\\',
-            'na_values': ['?'],
+            "quotechar": "'",
+            "escapechar": "\\",
+            "na_values": ["?"],
         },
         load_dataframe=load_dataframe,
     )
 
 
-def fetch_drug_directory(load_dataframe: bool = True
-                         ) -> Union[DatasetAll, DatasetInfoOnly]:
+def fetch_drug_directory(
+    load_dataframe: bool = True,
+) -> Union[DatasetAll, DatasetInfoOnly]:
     """Fetches the drug directory dataset (classification), available at
     https://openml.org/d/43044
 
@@ -581,12 +591,12 @@ def fetch_drug_directory(load_dataframe: bool = True
         If `load_dataframe=False`
     """
     return fetch_dataset_as_dataclass(
-        dataset_name='Drug directory',
+        dataset_name="Drug directory",
         dataset_id=DRUG_DIRECTORY_ID,
-        target='PRODUCTTYPENAME',
+        target="PRODUCTTYPENAME",
         read_csv_kwargs={
-            'quotechar': "'",
-            'escapechar': '\\',
+            "quotechar": "'",
+            "escapechar": "\\",
         },
         load_dataframe=load_dataframe,
     )

--- a/dirty_cat/datasets/tests/test_fetching.py
+++ b/dirty_cat/datasets/tests/test_fetching.py
@@ -2,27 +2,31 @@
 Tests fetching.py (datasets fetching off OpenML.org).
 """
 
-import pytest
 import shutil
 import warnings
-import pandas as pd
-
-from pathlib import Path
 from functools import wraps
 from json import JSONDecodeError
-from urllib.error import URLError
-
+from pathlib import Path
 from unittest import mock
 from unittest.mock import mock_open
+from urllib.error import URLError
+
+import pandas as pd
+import pytest
 
 from dirty_cat.datasets import fetching
-from dirty_cat.datasets.utils import get_data_dir as _get_data_dir
 from dirty_cat.datasets.fetching import (
-    _download_and_write_openml_dataset, _read_json_from_gz,
-    _features_to_csv_format, _export_gz_data_to_csv,
-    _get_details, _get_features, Details, Features,
-    fetch_openml_dataset as _fetch_openml_dataset,
+    Details,
+    Features,
+    _download_and_write_openml_dataset,
+    _export_gz_data_to_csv,
+    _features_to_csv_format,
+    _get_details,
+    _get_features,
+    _read_json_from_gz,
 )
+from dirty_cat.datasets.fetching import fetch_openml_dataset as _fetch_openml_dataset
+from dirty_cat.datasets.utils import get_data_dir as _get_data_dir
 
 
 @wraps(_fetch_openml_dataset)
@@ -33,7 +37,7 @@ def fetch_openml_dataset(*args, **kwargs):
     """
     with warnings.catch_warnings():
         warnings.simplefilter(
-            action='ignore',
+            action="ignore",
             category=UserWarning,
         )
         return _fetch_openml_dataset(*args, **kwargs)
@@ -68,13 +72,12 @@ def test_fetch_openml_dataset():
 
     try:  # Try-finally block used to remove the test data directory at the end
         try:
-
             # First, we want to purposefully test ValueError exceptions.
             with pytest.raises(ValueError):
-                assert fetch_openml_dataset(dataset_id=0,
-                                            data_directory=test_data_dir)
-                assert fetch_openml_dataset(dataset_id=2**32,
-                                            data_directory=test_data_dir)
+                assert fetch_openml_dataset(dataset_id=0, data_directory=test_data_dir)
+                assert fetch_openml_dataset(
+                    dataset_id=2**32, data_directory=test_data_dir
+                )
 
             # Valid call
             returned_info = fetch_openml_dataset(
@@ -90,8 +93,8 @@ def test_fetch_openml_dataset():
             # created by ``fetch_openml()``,  and the
             # ``.gz`` files within in order to finish the test.
             pytest.skip(
-                'Exception: Skipping this test because we encountered an '
-                'issue probably related to an Internet connection problem. '
+                "Exception: Skipping this test because we encountered an "
+                "issue probably related to an Internet connection problem. "
             )
             return
 
@@ -101,11 +104,14 @@ def test_fetch_openml_dataset():
 
         assert returned_info["path"].is_file()
 
-        dataset: pd.DataFrame = pd.read_csv(returned_info["path"], sep=",",
-                                            quotechar="'", escapechar="\\")
+        dataset: pd.DataFrame = pd.read_csv(
+            returned_info["path"], sep=",", quotechar="'", escapechar="\\"
+        )
 
-        assert dataset.shape == (test_dataset["dataset_rows_count"],
-                                 test_dataset["dataset_columns_count"])
+        assert dataset.shape == (
+            test_dataset["dataset_rows_count"],
+            test_dataset["dataset_columns_count"],
+        )
 
     finally:
         shutil.rmtree(path=str(test_data_dir), ignore_errors=True)
@@ -116,18 +122,20 @@ def test_fetch_openml_dataset():
 @mock.patch("dirty_cat.datasets.fetching._get_details")
 @mock.patch("dirty_cat.datasets.fetching._export_gz_data_to_csv")
 @mock.patch("dirty_cat.datasets.fetching._download_and_write_openml_dataset")
-def test_fetch_openml_dataset_mocked(mock_download, mock_export,
-                                     mock_get_details, mock_get_features,
-                                     mock_pathlib_path_isfile):
+def test_fetch_openml_dataset_mocked(
+    mock_download,
+    mock_export,
+    mock_get_details,
+    mock_get_features,
+    mock_pathlib_path_isfile,
+):
     """
     Test function ``fetch_openml_dataset()``, but this time,
     we mock the functions to test its inner mechanisms.
     """
 
     mock_get_details.return_value = Details(
-        name="Dataset_name",
-        file_id="123456",
-        description="Dummy dataset description."
+        name="Dataset_name", file_id="123456", description="Dummy dataset description."
     )
     mock_get_features.return_value = Features(
         names=["id", "name", "transaction_id", "owner", "recipient"]
@@ -154,14 +162,13 @@ def test_fetch_openml_dataset_mocked(mock_download, mock_export,
     fetch_openml_dataset(50, test_data_dir)
 
     # Download should be called twice
-    mock_download.assert_called_with(dataset_id=50,
-                                     data_directory=get_test_data_dir())
+    mock_download.assert_called_with(dataset_id=50, data_directory=get_test_data_dir())
     mock_export.assert_called_once()
     mock_get_features.assert_called_once()
     mock_get_details.assert_called_once()
 
 
-@mock.patch('dirty_cat.datasets.fetching.fetch_openml')
+@mock.patch("dirty_cat.datasets.fetching.fetch_openml")
 def test__download_and_write_openml_dataset(mock_fetch_openml):
     """Tests function ``_download_and_write_openml_dataset()``."""
 
@@ -170,9 +177,9 @@ def test__download_and_write_openml_dataset(mock_fetch_openml):
     test_data_dir = get_test_data_dir()
     _download_and_write_openml_dataset(dataset_id, test_data_dir)
 
-    mock_fetch_openml.assert_called_once_with(data_id=dataset_id,
-                                              data_home=str(test_data_dir),
-                                              as_frame=True)
+    mock_fetch_openml.assert_called_once_with(
+        data_id=dataset_id, data_home=str(test_data_dir), as_frame=True
+    )
 
 
 @mock.patch("dirty_cat.datasets.fetching.Path.is_file")
@@ -189,16 +196,18 @@ def test__read_json_from_gz(mock_pathlib_path_isfile):
     # Passing a valid file path,
     # but reading it does not return JSON-encoded data.
     mock_pathlib_path_isfile.return_value = True
-    with mock.patch("gzip.open", mock_open(
-            read_data='This is not JSON-encoded data!')) as _:
+    with mock.patch(
+        "gzip.open", mock_open(read_data="This is not JSON-encoded data!")
+    ) as _:
         with pytest.raises(JSONDecodeError):
             assert _read_json_from_gz(dummy_file_path)
 
     # Passing a valid file path, and reading it
     # returns valid JSON-encoded data.
     expected_return_value = {"data": "This is JSON-encoded data!"}
-    with mock.patch("gzip.open", mock_open(
-            read_data='{"data": "This is JSON-encoded data!"}')) as _:
+    with mock.patch(
+        "gzip.open", mock_open(read_data='{"data": "This is JSON-encoded data!"}')
+    ) as _:
         assert _read_json_from_gz(dummy_file_path) == expected_return_value
 
 
@@ -206,8 +215,9 @@ def test__read_json_from_gz(mock_pathlib_path_isfile):
 def test__get_details(mock_read_json_from_gz):
     """Tests function ``_get_details()``."""
 
-    expected_return_value = Details("Dataset_name", "123456",
-                                    "Dummy dataset description.")
+    expected_return_value = Details(
+        "Dataset_name", "123456", "Dummy dataset description."
+    )
 
     mock_read_json_from_gz.return_value = {
         "data_set_description": {
@@ -228,8 +238,9 @@ def test__get_details(mock_read_json_from_gz):
 def test__get_features(mock_read_json_from_gz):
     """Tests function ``_get_features()``."""
 
-    expected_return_value = Features(["id", "name", "transaction_id",
-                                      "owner", "recipient"])
+    expected_return_value = Features(
+        ["id", "name", "transaction_id", "owner", "recipient"]
+    )
 
     mock_read_json_from_gz.return_value = {
         "data_features": {
@@ -251,16 +262,20 @@ def test__get_features(mock_read_json_from_gz):
 def test__export_gz_data_to_csv():
     """Tests function ``_export_gz_data_to_csv()``."""
 
-    features = Features(["top-left-square",
-                         "top-middle-square",
-                         "top-right-square",
-                         "middle-left-square",
-                         "middle-middle-square",
-                         "middle-right-square",
-                         "bottom-left-square",
-                         "bottom-middle-square",
-                         "bottom-right-square",
-                         "Class"])
+    features = Features(
+        [
+            "top-left-square",
+            "top-middle-square",
+            "top-right-square",
+            "middle-left-square",
+            "middle-middle-square",
+            "middle-right-square",
+            "bottom-left-square",
+            "bottom-middle-square",
+            "bottom-right-square",
+            "Class",
+        ]
+    )
     arff_data = (
         "% This is a comment\n"
         "@relation tic-tac-toe\n"
@@ -273,15 +288,13 @@ def test__export_gz_data_to_csv():
     dummy_gz = Path("/dummy/file.gz")
     dummy_csv = Path("/dummy/file.csv")
 
-    with mock.patch("pathlib.Path.open",
-                    mock_open(read_data="")) as mock_pathlib_path_open:
-        with mock.patch("gzip.open",
-                        mock_open(read_data=arff_data)) as mock_gzip_open:
+    with mock.patch(
+        "pathlib.Path.open", mock_open(read_data="")
+    ) as mock_pathlib_path_open:
+        with mock.patch("gzip.open", mock_open(read_data=arff_data)) as mock_gzip_open:
             _export_gz_data_to_csv(dummy_gz, dummy_csv, features)
-            mock_pathlib_path_open.assert_called_with(mode='w',
-                                                      encoding='utf8')
-            mock_gzip_open.assert_called_with(dummy_gz, mode='rt',
-                                              encoding='utf8')
+            mock_pathlib_path_open.assert_called_with(mode="w", encoding="utf8")
+            mock_gzip_open.assert_called_with(dummy_gz, mode="rt", encoding="utf8")
 
 
 def test__features_to_csv_format():
@@ -292,37 +305,42 @@ def test__features_to_csv_format():
     assert _features_to_csv_format(features) == expected_return_value
 
 
-@mock.patch('dirty_cat.datasets.fetching.fetch_openml_dataset')
+@mock.patch("dirty_cat.datasets.fetching.fetch_openml_dataset")
 @mock.patch("dirty_cat.datasets.fetching.fetch_dataset_as_dataclass")
-def test_import_all_datasets(mock_fetch_dataset_as_dataclass,
-                             mock_fetch_openml_dataset):
+def test_import_all_datasets(
+    mock_fetch_dataset_as_dataclass, mock_fetch_openml_dataset
+):
     """Tests functions ``fetch_*()``."""
 
     mock_fetch_openml_dataset.return_value = {
-        'name': 'Example dataset',
-        'description': 'This is a dataset.',
-        'source': 'https://www.openml.org/',
-        'target': 'To_predict',
-        'path': Path("/path/to/file.csv"),
-        'read_csv_kwargs': {'a': 'b'},
+        "name": "Example dataset",
+        "description": "This is a dataset.",
+        "source": "https://www.openml.org/",
+        "target": "To_predict",
+        "path": Path("/path/to/file.csv"),
+        "read_csv_kwargs": {"a": "b"},
     }
 
     expected_return_value_all = fetching.DatasetAll(
-        name='Example dataset',
+        name="Example dataset",
         description="This is a dataset.",
         source="https://www.openml.org/",
         path=Path("/path/to/file.csv"),
         X=pd.DataFrame([1, 2, 3, 4]),
-        y=pd.Series([5, ]),
+        y=pd.Series(
+            [
+                5,
+            ]
+        ),
     )
 
     expected_return_value_info_only = fetching.DatasetInfoOnly(
-        name='Example dataset',
+        name="Example dataset",
         description="This is a dataset.",
         source="https://www.openml.org/",
-        target='To_predict',
+        target="To_predict",
         path=Path("/path/to/file.csv"),
-        read_csv_kwargs={'a': 'b'},
+        read_csv_kwargs={"a": "b"},
     )
 
     for expected_return_value, load_dataframe in zip(
@@ -332,7 +350,8 @@ def test_import_all_datasets(mock_fetch_dataset_as_dataclass,
         mock_fetch_dataset_as_dataclass.return_value = expected_return_value
 
         returned_value = fetching.fetch_employee_salaries(
-            drop_linked=False, drop_irrelevant=False)
+            drop_linked=False, drop_irrelevant=False
+        )
         assert expected_return_value == returned_value
 
         mock_fetch_openml_dataset.reset_mock()

--- a/dirty_cat/datasets/tests/test_utils.py
+++ b/dirty_cat/datasets/tests/test_utils.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest import mock
 
 
-@mock.patch('os.path.dirname')
+@mock.patch("os.path.dirname")
 def test_get_data_dir(mock_os_path_dirname):
     """
     Tests function ``get_data_dir()``.

--- a/dirty_cat/datasets/utils.py
+++ b/dirty_cat/datasets/utils.py
@@ -12,7 +12,7 @@ def get_data_dir(name: str = None) -> Path:
     # Note: we stick to os.path instead of pathlib.Path because
     # it's easier to test, and the functionality is the same.
     module_path = Path(os.path.dirname(__file__)).resolve()
-    data_dir = module_path / 'data'
+    data_dir = module_path / "data"
     if name is not None:
         data_dir = data_dir / name
     return data_dir

--- a/dirty_cat/fast_hash.py
+++ b/dirty_cat/fast_hash.py
@@ -15,11 +15,12 @@ The principle is as follows:
 """
 
 import functools
+
 import numpy as np
 
 # Precompute to avoid the cost and
 # cast to int32 to speed up the min
-MININT32 = np.int32(-2 ** (32 - 1))
+MININT32 = np.int32(-(2 ** (32 - 1)))
 MAXINT32 = np.int32(2 ** (32 - 1) - 1)
 
 
@@ -42,8 +43,7 @@ def gen_atom(atom_len, seed=0):
         (assuming dtype_size=32).
     """
     rng = np.random.RandomState(seed)
-    atom = rng.randint(-MAXINT32, MAXINT32, size=atom_len,
-                       dtype=np.dtype('int32'))
+    atom = rng.randint(-MAXINT32, MAXINT32, size=atom_len, dtype=np.dtype("int32"))
     return atom
 
 
@@ -56,7 +56,7 @@ def ngram_min_hash(string, ngram_range=(2, 4), seed=0, return_minmax=False):
     string : str
         String to encode.
     ngram_range : tuple (min_n, max_n), default=(2, 4)
-        The lower and upper boundary of the range of n-values 
+        The lower and upper boundary of the range of n-values
         for different n-grams to be extracted.
     seed : int, default=0
         Integer used to seed the hashing function.
@@ -66,11 +66,11 @@ def ngram_min_hash(string, ngram_range=(2, 4), seed=0, return_minmax=False):
 
     Returns
     -------
-    int or tuple 
+    int or tuple
         The min_hash or (min_hash, max_hash) of the n-grams of the string.
     """
     # Create a numerical 1D array from the string
-    array = np.frombuffer(string.encode(), dtype='int8', count=len(string))
+    array = np.frombuffer(string.encode(), dtype="int8", count=len(string))
 
     max_hash = MININT32
     min_hash = MAXINT32
@@ -90,9 +90,10 @@ def ngram_min_hash(string, ngram_range=(2, 4), seed=0, return_minmax=False):
     return min_hash
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Download demo text
     from sklearn import datasets
+
     data = datasets.fetch_20newsgroups()
     a = data.data[0]
 

--- a/dirty_cat/gap_encoder.py
+++ b/dirty_cat/gap_encoder.py
@@ -16,38 +16,37 @@ The principle is as follows:
 """
 
 import warnings
+from typing import Dict, Generator, List, Literal, Optional, Tuple, Union
+
 import numpy as np
 import pandas as pd
-
-from scipy import sparse
 from numpy.random import RandomState
-from typing import Tuple, Optional, Union, Literal, Dict, List, Generator
-
-from sklearn.cluster import KMeans
-from sklearn.neighbors import NearestNeighbors
+from scipy import sparse
 from sklearn import __version__ as sklearn_version
-from sklearn.utils.fixes import _object_dtype_isnan
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.cluster import KMeans
+from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
+from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_random_state, gen_batches
 from sklearn.utils.extmath import row_norms, safe_sparse_dot
-from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
+from sklearn.utils.fixes import _object_dtype_isnan
 
-from .utils import check_input
 from dirty_cat.utils import Version
 
+from .utils import check_input
 
-if Version(sklearn_version) == Version('0.22'):
+if Version(sklearn_version) == Version("0.22"):
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
+        warnings.simplefilter("ignore")
         from sklearn.cluster.k_means_ import _k_init
-elif Version(sklearn_version) < Version('0.24'):
+elif Version(sklearn_version) < Version("0.24"):
     from sklearn.cluster._kmeans import _k_init
 else:
     from sklearn.cluster import kmeans_plusplus
 
-if Version(sklearn_version) == Version('0.22'):
+if Version(sklearn_version) == Version("0.22"):
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
+        warnings.simplefilter("ignore")
         from sklearn.decomposition.nmf import _beta_divergence
 else:
     from sklearn.decomposition._nmf import _beta_divergence
@@ -60,26 +59,27 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
     rho_: float
     H_dict_: Dict[np.array, np.array]
 
-    def __init__(self,
-                 n_components: int = 10,
-                 batch_size: int = 128,
-                 gamma_shape_prior: float = 1.1,
-                 gamma_scale_prior: float = 1.0,
-                 rho: float = .95,
-                 rescale_rho: bool = False,
-                 hashing: bool = False,
-                 hashing_n_features: int = 2**12,
-                 init: Literal["k-means++", "random", "k-means"] = 'k-means++',
-                 tol: float = 1e-4,
-                 min_iter: int = 2,
-                 max_iter: int = 5,
-                 ngram_range: Tuple[int, int] = (2, 4),
-                 analyzer: Literal["word", "char", "char_wb"] = 'char',
-                 add_words: bool = False,
-                 random_state: Optional[Union[int, RandomState]] = None,
-                 rescale_W: bool = True,
-                 max_iter_e_step: int = 20):
-
+    def __init__(
+        self,
+        n_components: int = 10,
+        batch_size: int = 128,
+        gamma_shape_prior: float = 1.1,
+        gamma_scale_prior: float = 1.0,
+        rho: float = 0.95,
+        rescale_rho: bool = False,
+        hashing: bool = False,
+        hashing_n_features: int = 2**12,
+        init: Literal["k-means++", "random", "k-means"] = "k-means++",
+        tol: float = 1e-4,
+        min_iter: int = 2,
+        max_iter: int = 5,
+        ngram_range: Tuple[int, int] = (2, 4),
+        analyzer: Literal["word", "char", "char_wb"] = "char",
+        add_words: bool = False,
+        random_state: Optional[Union[int, RandomState]] = None,
+        rescale_W: bool = True,
+        max_iter_e_step: int = 20,
+    ):
         self.ngram_range = ngram_range
         self.n_components = n_components
         self.gamma_shape_prior = gamma_shape_prior  # 'a' parameter
@@ -107,18 +107,23 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         # Init n-grams counts vectorizer
         if self.hashing:
             self.ngrams_count_ = HashingVectorizer(
-                 analyzer=self.analyzer, ngram_range=self.ngram_range,
-                 n_features=self.hashing_n_features,
-                 norm=None, alternate_sign=False)
+                analyzer=self.analyzer,
+                ngram_range=self.ngram_range,
+                n_features=self.hashing_n_features,
+                norm=None,
+                alternate_sign=False,
+            )
             if self.add_words:  # Init a word counts vectorizer if needed
                 self.word_count_ = HashingVectorizer(
-                     analyzer='word',
-                     n_features=self.hashing_n_features,
-                     norm=None, alternate_sign=False)
+                    analyzer="word",
+                    n_features=self.hashing_n_features,
+                    norm=None,
+                    alternate_sign=False,
+                )
         else:
             self.ngrams_count_ = CountVectorizer(
-                 analyzer=self.analyzer, ngram_range=self.ngram_range,
-                 dtype=np.float64)
+                analyzer=self.analyzer, ngram_range=self.ngram_range, dtype=np.float64
+            )
             if self.add_words:
                 self.word_count_ = CountVectorizer(dtype=np.float64)
 
@@ -129,24 +134,22 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         unq_V = self.ngrams_count_.fit_transform(unq_X)
         if self.add_words:  # Add word counts to unq_V
             unq_V2 = self.word_count_.fit_transform(unq_X)
-            unq_V = sparse.hstack((unq_V, unq_V2), format='csr')
+            unq_V = sparse.hstack((unq_V, unq_V2), format="csr")
 
         if not self.hashing:  # Build n-grams/word vocabulary
-            if Version(sklearn_version) < Version('1.0'):
+            if Version(sklearn_version) < Version("1.0"):
                 self.vocabulary = self.ngrams_count_.get_feature_names()
             else:
                 self.vocabulary = self.ngrams_count_.get_feature_names_out()
             if self.add_words:
-                if Version(sklearn_version) < Version('1.0'):
-                    self.vocabulary = np.concatenate((
-                        self.vocabulary,
-                        self.word_count_.get_feature_names()
-                    ))
+                if Version(sklearn_version) < Version("1.0"):
+                    self.vocabulary = np.concatenate(
+                        (self.vocabulary, self.word_count_.get_feature_names())
+                    )
                 else:
-                    self.vocabulary = np.concatenate((
-                        self.vocabulary,
-                        self.word_count_.get_feature_names_out()
-                    ))
+                    self.vocabulary = np.concatenate(
+                        (self.vocabulary, self.word_count_.get_feature_names_out())
+                    )
         _, self.n_vocab = unq_V.shape
         # Init the topics W given the n-grams counts V
         self.W_, self.A_, self.B_ = self._init_w(unq_V[lookup], X)
@@ -178,52 +181,69 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         If self.init='k-means', topics are initialized with a KMeans on the
         n-grams counts.
         """
-        if self.init == 'k-means++':
-            if Version(sklearn_version) < Version('0.24'):
-                W = _k_init(
-                    V, self.n_components,
-                    x_squared_norms=row_norms(V, squared=True),
-                    random_state=self.random_state,
-                    n_local_trials=None) + .1
+        if self.init == "k-means++":
+            if Version(sklearn_version) < Version("0.24"):
+                W = (
+                    _k_init(
+                        V,
+                        self.n_components,
+                        x_squared_norms=row_norms(V, squared=True),
+                        random_state=self.random_state,
+                        n_local_trials=None,
+                    )
+                    + 0.1
+                )
             else:
                 W, _ = kmeans_plusplus(
-                    V, self.n_components,
+                    V,
+                    self.n_components,
                     x_squared_norms=row_norms(V, squared=True),
                     random_state=self.random_state,
-                    n_local_trials=None)
-                W = W + .1  # To avoid restricting topics to a few n-grams only
-        elif self.init == 'random':
+                    n_local_trials=None,
+                )
+                W = W + 0.1  # To avoid restricting topics to a few n-grams only
+        elif self.init == "random":
             W = self.random_state.gamma(
-                shape=self.gamma_shape_prior, scale=self.gamma_scale_prior,
-                size=(self.n_components, self.n_vocab))
-        elif self.init == 'k-means':
-            prototypes = get_kmeans_prototypes(X, self.n_components,
-                                               analyzer=self.analyzer,
-                                               random_state=self.random_state)
-            W = self.ngrams_count_.transform(prototypes).A + .1
+                shape=self.gamma_shape_prior,
+                scale=self.gamma_scale_prior,
+                size=(self.n_components, self.n_vocab),
+            )
+        elif self.init == "k-means":
+            prototypes = get_kmeans_prototypes(
+                X,
+                self.n_components,
+                analyzer=self.analyzer,
+                random_state=self.random_state,
+            )
+            W = self.ngrams_count_.transform(prototypes).A + 0.1
             if self.add_words:
-                W2 = self.word_count_.transform(prototypes).A + .1
+                W2 = self.word_count_.transform(prototypes).A + 0.1
                 W = np.hstack((W, W2))
             # if k-means doesn't find the exact number of prototypes
             if W.shape[0] < self.n_components:
-                if Version(sklearn_version) < Version('0.24'):
-                    W2 = _k_init(
-                        V, self.n_components - W.shape[0],
-                        x_squared_norms=row_norms(V, squared=True),
-                        random_state=self.random_state,
-                        n_local_trials=None) + .1
+                if Version(sklearn_version) < Version("0.24"):
+                    W2 = (
+                        _k_init(
+                            V,
+                            self.n_components - W.shape[0],
+                            x_squared_norms=row_norms(V, squared=True),
+                            random_state=self.random_state,
+                            n_local_trials=None,
+                        )
+                        + 0.1
+                    )
                 else:
                     W2, _ = kmeans_plusplus(
-                        V, self.n_components - W.shape[0],
+                        V,
+                        self.n_components - W.shape[0],
                         x_squared_norms=row_norms(V, squared=True),
                         random_state=self.random_state,
-                        n_local_trials=None)
-                    W2 = W2 + .1
+                        n_local_trials=None,
+                    )
+                    W2 = W2 + 0.1
                 W = np.concatenate((W, W2), axis=0)
         else:
-            raise ValueError(
-                f'Initialization method {self.init!r} does not exist. '
-            )
+            raise ValueError(f"Initialization method {self.init!r} does not exist. ")
         W /= W.sum(axis=1, keepdims=True)
         A = np.ones((self.n_components, self.n_vocab)) * 1e-10
         B = A.copy()
@@ -239,7 +259,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             The string data to fit the model on.
         y : None
             Unused, only here for compatibility.
-        
+
         Returns
         -------
         self
@@ -258,26 +278,34 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
 
         for n_iter_ in range(self.max_iter):
             # Loop over batches
-            for i, (unq_idx, idx) in enumerate(batch_lookup(
-              lookup, n=self.batch_size)):
-                if i == n_batch-1:
+            for i, (unq_idx, idx) in enumerate(batch_lookup(lookup, n=self.batch_size)):
+                if i == n_batch - 1:
                     W_last = self.W_.copy()
                 # Update activations unq_H
                 unq_H[unq_idx] = _multiplicative_update_h(
-                    unq_V[unq_idx], self.W_, unq_H[unq_idx],
-                    epsilon=1e-3, max_iter=self.max_iter_e_step,
+                    unq_V[unq_idx],
+                    self.W_,
+                    unq_H[unq_idx],
+                    epsilon=1e-3,
+                    max_iter=self.max_iter_e_step,
                     rescale_W=self.rescale_W,
                     gamma_shape_prior=self.gamma_shape_prior,
-                    gamma_scale_prior=self.gamma_scale_prior)
+                    gamma_scale_prior=self.gamma_scale_prior,
+                )
                 # Update the topics self.W_
                 _multiplicative_update_w(
-                    unq_V[idx], self.W_, self.A_, self.B_, unq_H[idx],
-                    self.rescale_W, self.rho_)
+                    unq_V[idx],
+                    self.W_,
+                    self.A_,
+                    self.B_,
+                    unq_H[idx],
+                    self.rescale_W,
+                    self.rho_,
+                )
 
-                if i == n_batch-1:
+                if i == n_batch - 1:
                     # Compute the norm of the update of W in the last batch
-                    W_change = np.linalg.norm(
-                        self.W_ - W_last) / np.linalg.norm(W_last)
+                    W_change = np.linalg.norm(self.W_ - W_last) / np.linalg.norm(W_last)
 
             if (W_change < self.tol) and (n_iter_ >= self.min_iter - 1):
                 break  # Stop if the change in W is smaller than the tolerance
@@ -286,7 +314,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         self.H_dict_.update(zip(unq_X, unq_H))
         return self
 
-    def get_feature_names(self, n_labels=3, prefix=''):
+    def get_feature_names(self, n_labels=3, prefix=""):
         """
         Ensures compatibility with sklearn < 1.0.
         Use `get_feature_names_out` instead.
@@ -300,8 +328,11 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         )
         return self.get_feature_names_out(n_labels=n_labels, prefix=prefix)
 
-    def get_feature_names_out(self, n_labels: int = 3, prefix: str = '',
-                              ) -> List[str]:
+    def get_feature_names_out(
+        self,
+        n_labels: int = 3,
+        prefix: str = "",
+    ) -> List[str]:
         """
         Returns the labels that best summarize the learned components/topics.
         For each topic, labels with the highest activations are selected.
@@ -321,7 +352,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
 
         vectorizer = CountVectorizer()
         vectorizer.fit(list(self.H_dict_.keys()))
-        if Version(sklearn_version) < Version('1.0'):
+        if Version(sklearn_version) < Version("1.0"):
             vocabulary = np.array(vectorizer.get_feature_names())
         else:
             vocabulary = np.array(vectorizer.get_feature_names_out())
@@ -334,7 +365,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             x = encoding[:, i]
             labels = vocabulary[np.argsort(-x)[:n_labels]]
             topic_labels.append(labels)
-        topic_labels = [prefix + ', '.join(label) for label in topic_labels]
+        topic_labels = [prefix + ", ".join(label) for label in topic_labels]
         return topic_labels
 
     def score(self, X) -> float:
@@ -358,23 +389,26 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         unq_V = self.ngrams_count_.transform(unq_X)
         if self.add_words:
             unq_V2 = self.word_count_.transform(unq_X)
-            unq_V = sparse.hstack((unq_V, unq_V2), format='csr')
+            unq_V = sparse.hstack((unq_V, unq_V2), format="csr")
 
         self._add_unseen_keys_to_H_dict(unq_X)
         unq_H = self._get_H(unq_X)
         # Given the learnt topics W, optimize the activations H to fit V = HW
-        for slice in gen_batches(n=unq_H.shape[0],
-                                 batch_size=self.batch_size):
+        for slice in gen_batches(n=unq_H.shape[0], batch_size=self.batch_size):
             unq_H[slice] = _multiplicative_update_h(
-                unq_V[slice], self.W_, unq_H[slice],
-                epsilon=1e-3, max_iter=self.max_iter_e_step,
+                unq_V[slice],
+                self.W_,
+                unq_H[slice],
+                epsilon=1e-3,
+                max_iter=self.max_iter_e_step,
                 rescale_W=self.rescale_W,
                 gamma_shape_prior=self.gamma_shape_prior,
-                gamma_scale_prior=self.gamma_scale_prior)
+                gamma_scale_prior=self.gamma_scale_prior,
+            )
         # Compute the KL divergence between V and HW
         kl_divergence = _beta_divergence(
-            unq_V[lookup], unq_H[lookup], self.W_,
-            'kullback-leibler', square_root=False)
+            unq_V[lookup], unq_H[lookup], self.W_, "kullback-leibler", square_root=False
+        )
         return kl_divergence
 
     def partial_fit(self, X, y=None) -> "GapEncoderColumn":
@@ -389,57 +423,68 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             The string data to fit the model on.
         y : None
             Unused, only here for compatibility.
-        
+
         Returns
         -------
         GapEncoderColumn
             The fitted GapEncoderColumn instance.
         """
-        
+
         # Init H_dict_ with empty dict if it's the first call of partial_fit
-        if not hasattr(self, 'H_dict_'):
+        if not hasattr(self, "H_dict_"):
             self.H_dict_ = dict()
         # Same thing for the rho_ parameter
-        if not hasattr(self, 'rho_'):
+        if not hasattr(self, "rho_"):
             self.rho_ = self.rho
         # Check if first item has str or np.str_ type
         assert isinstance(X[0], str), "Input data is not string. "
         # Check if it is not the first batch
-        if hasattr(self, 'vocabulary'):  # Update unq_X, unq_V with new batch
+        if hasattr(self, "vocabulary"):  # Update unq_X, unq_V with new batch
             unq_X, lookup = np.unique(X, return_inverse=True)
             unq_V = self.ngrams_count_.transform(unq_X)
             if self.add_words:
                 unq_V2 = self.word_count_.transform(unq_X)
-                unq_V = sparse.hstack((unq_V, unq_V2), format='csr')
+                unq_V = sparse.hstack((unq_V, unq_V2), format="csr")
 
             unseen_X = np.setdiff1d(unq_X, np.array([*self.H_dict_]))
             unseen_V = self.ngrams_count_.transform(unseen_X)
             if self.add_words:
                 unseen_V2 = self.word_count_.transform(unseen_X)
-                unseen_V = sparse.hstack((unseen_V, unseen_V2), format='csr')
+                unseen_V = sparse.hstack((unseen_V, unseen_V2), format="csr")
 
             if unseen_V.shape[0] != 0:
                 unseen_H = _rescale_h(
-                    unseen_V, np.ones((len(unseen_X), self.n_components)))
+                    unseen_V, np.ones((len(unseen_X), self.n_components))
+                )
                 for x, h in zip(unseen_X, unseen_H):
                     self.H_dict_[x] = h
                 del unseen_H
             del unseen_X, unseen_V
-        else: # If it is the first batch, call _init_vars to init unq_X, unq_V
+        else:  # If it is the first batch, call _init_vars to init unq_X, unq_V
             unq_X, unq_V, lookup = self._init_vars(X)
 
         unq_H = self._get_H(unq_X)
         # Update unq_H, the activations
         unq_H = _multiplicative_update_h(
-            unq_V, self.W_, unq_H,
-            epsilon=1e-3, max_iter=self.max_iter_e_step,
+            unq_V,
+            self.W_,
+            unq_H,
+            epsilon=1e-3,
+            max_iter=self.max_iter_e_step,
             rescale_W=self.rescale_W,
             gamma_shape_prior=self.gamma_shape_prior,
-            gamma_scale_prior=self.gamma_scale_prior)
+            gamma_scale_prior=self.gamma_scale_prior,
+        )
         # Update the topics self.W_
         _multiplicative_update_w(
-            unq_V[lookup], self.W_, self.A_, self.B_,
-            unq_H[lookup], self.rescale_W, self.rho_)
+            unq_V[lookup],
+            self.W_,
+            self.A_,
+            self.B_,
+            unq_H[lookup],
+            self.rescale_W,
+            self.rho_,
+        )
         # Update self.H_dict_ with the learned encoded vectors (activations)
         self.H_dict_.update(zip(unq_X, unq_H))
         return self
@@ -453,10 +498,11 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             unseen_V = self.ngrams_count_.transform(unseen_X)
             if self.add_words:
                 unseen_V2 = self.word_count_.transform(unseen_X)
-                unseen_V = sparse.hstack((unseen_V, unseen_V2), format='csr')
+                unseen_V = sparse.hstack((unseen_V, unseen_V2), format="csr")
 
             unseen_H = _rescale_h(
-                unseen_V, np.ones((unseen_V.shape[0], self.n_components)))
+                unseen_V, np.ones((unseen_V.shape[0], self.n_components))
+            )
             self.H_dict_.update(zip(unseen_X, unseen_H))
 
     def transform(self, X) -> np.array:
@@ -479,22 +525,25 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         unq_X = np.unique(X)
         # Build the n-grams counts matrix V for the string data to encode
         unq_V = self.ngrams_count_.transform(unq_X)
-        if self.add_words: # Add words counts
+        if self.add_words:  # Add words counts
             unq_V2 = self.word_count_.transform(unq_X)
-            unq_V = sparse.hstack((unq_V, unq_V2), format='csr')
+            unq_V = sparse.hstack((unq_V, unq_V2), format="csr")
         # Add unseen strings in X to H_dict
         self._add_unseen_keys_to_H_dict(unq_X)
         unq_H = self._get_H(unq_X)
         # Loop over batches
-        for slc in gen_batches(n=unq_H.shape[0],
-                               batch_size=self.batch_size):
+        for slc in gen_batches(n=unq_H.shape[0], batch_size=self.batch_size):
             # Given the learnt topics W, optimize H to fit V = HW
             unq_H[slc] = _multiplicative_update_h(
-                unq_V[slc], self.W_, unq_H[slc],
-                epsilon=1e-3, max_iter=100,
+                unq_V[slc],
+                self.W_,
+                unq_H[slc],
+                epsilon=1e-3,
+                max_iter=100,
                 rescale_W=self.rescale_W,
                 gamma_shape_prior=self.gamma_shape_prior,
-                gamma_scale_prior=self.gamma_scale_prior)
+                gamma_scale_prior=self.gamma_scale_prior,
+            )
         # Store and return the encoded vectors of X
         self.H_dict_.update(zip(unq_X, unq_H))
         return self._get_H(X)
@@ -581,34 +630,35 @@ class GapEncoder(BaseEstimator, TransformerMixin):
     For a detailed description of the method, see
     `Encoding high-cardinality string categorical variables
     <https://hal.inria.fr/hal-02171256v4>`_ by Cerda, Varoquaux (2019).
-    
+
     """
 
     rho_: float
     fitted_models_: List[GapEncoderColumn]
     column_names_: List[str]
 
-    def __init__(self,
-                 n_components: int = 10,
-                 batch_size: int = 128,
-                 gamma_shape_prior: float = 1.1,
-                 gamma_scale_prior: float = 1.0,
-                 rho: float = .95,
-                 rescale_rho: bool = False,
-                 hashing: bool = False,
-                 hashing_n_features: int = 2**12,
-                 init: Literal["k-means++", "random", "k-means"] = 'k-means++',
-                 tol: float = 1e-4,
-                 min_iter: int = 2,
-                 max_iter: int = 5,
-                 ngram_range: Tuple[int, int] = (2, 4),
-                 analyzer: Literal["word", "char", "char_wb"] = 'char',
-                 add_words: bool = False,
-                 random_state: Optional[Union[int, RandomState]] = None,
-                 rescale_W: bool = True,
-                 max_iter_e_step: int = 20,
-                 handle_missing: Literal["error", "empty_impute"] = 'zero_impute'):
-
+    def __init__(
+        self,
+        n_components: int = 10,
+        batch_size: int = 128,
+        gamma_shape_prior: float = 1.1,
+        gamma_scale_prior: float = 1.0,
+        rho: float = 0.95,
+        rescale_rho: bool = False,
+        hashing: bool = False,
+        hashing_n_features: int = 2**12,
+        init: Literal["k-means++", "random", "k-means"] = "k-means++",
+        tol: float = 1e-4,
+        min_iter: int = 2,
+        max_iter: int = 5,
+        ngram_range: Tuple[int, int] = (2, 4),
+        analyzer: Literal["word", "char", "char_wb"] = "char",
+        add_words: bool = False,
+        random_state: Optional[Union[int, RandomState]] = None,
+        rescale_W: bool = True,
+        max_iter_e_step: int = 20,
+        handle_missing: Literal["error", "empty_impute"] = "zero_impute",
+    ):
         self.ngram_range = ngram_range
         self.n_components = n_components
         self.gamma_shape_prior = gamma_shape_prior  # 'a' parameter
@@ -639,7 +689,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         return GapEncoderColumn(
             ngram_range=self.ngram_range,
             n_components=self.n_components,
-            analyzer = self.analyzer,
+            analyzer=self.analyzer,
             gamma_shape_prior=self.gamma_shape_prior,
             gamma_scale_prior=self.gamma_scale_prior,
             rho=self.rho,
@@ -661,22 +711,22 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         Imputes missing values with `` or raises an error
         Note: modifies the array in-place.
         """
-        if self.handle_missing not in ['error', 'zero_impute']:
+        if self.handle_missing not in ["error", "zero_impute"]:
             raise ValueError(
-                f"handle_missing should be either 'error' or "
+                "handle_missing should be either 'error' or "
                 f"'zero_impute', got {self.handle_missing!r}. "
             )
 
         missing_mask = _object_dtype_isnan(X)
 
         if missing_mask.any():
-            if self.handle_missing == 'error':
-                raise ValueError('Input data contains missing values. ')
-            elif self.handle_missing == 'zero_impute':
-                X[missing_mask] = ''
+            if self.handle_missing == "error":
+                raise ValueError("Input data contains missing values. ")
+            elif self.handle_missing == "zero_impute":
+                X[missing_mask] = ""
 
         return X
-            
+
     def fit(self, X, y=None) -> "GapEncoder":
         """
         Fit the GapEncoder on batches of X.
@@ -687,7 +737,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
             The string data to fit the model on.
         y : None
             Unused, only here for compatibility.
-        
+
         Returns
         -------
         GapEncoder
@@ -714,10 +764,10 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         Given the learnt topics W, the activations H are tuned to fit V = HW.
         When X has several columns, they are encoded separately and
         then concatenated.
-        
+
         Remark: calling transform multiple times in a row on the same
         input X can give slightly different encodings. This is expected
-        due to a caching mechanism to speed things up.        
+        due to a caching mechanism to speed things up.
 
         Parameters
         ----------
@@ -766,7 +816,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         X = self._handle_missing(X)
         # Init the `GapEncoderColumn` instances if the model was
         # not fitted already.
-        if not hasattr(self, 'fitted_models_'):
+        if not hasattr(self, "fitted_models_"):
             self.fitted_models_ = [
                 self._create_column_gap_encoder() for _ in range(X.shape[1])
             ]
@@ -774,24 +824,25 @@ class GapEncoder(BaseEstimator, TransformerMixin):
             self.fitted_models_[k].partial_fit(X[:, k])
         return self
 
-    def get_feature_names_out(self,
-                              col_names: Optional[Union[Literal["auto"],
-                                                        List[str]]] = None,
-                              n_labels: int = 3):
+    def get_feature_names_out(
+        self,
+        col_names: Optional[Union[Literal["auto"], List[str]]] = None,
+        n_labels: int = 3,
+    ):
         """
         Returns the labels that best summarize the learned components/topics.
         For each topic, labels with the highest activations are selected.
 
         Parameters
         ----------
-        col_names : typing.Optional[typing.Union[typing.Literal["auto"], typing.List[str]]], default=None
+        col_names : typing.Optional[typing.Union[typing.Literal["auto"], typing.List[str]]], default=None  # noqa
             The column names to be added as prefixes before the labels.
             If col_names == None, no prefixes are used.
             If col_names == 'auto', column names are automatically defined:
                 - if the input data was a dataframe, its column names are used,
                 - otherwise, 'col1', ..., 'colN' are used as prefixes.
             Prefixes can be manually set by passing a list for col_names.
-            
+
         n_labels : int, default=3
             The number of labels used to describe each topic.
 
@@ -800,36 +851,33 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         topic_labels : list of strings
             The labels that best describe each topic.
         """
-        assert hasattr(self, 'fitted_models_'), (
-            'ERROR: GapEncoder must be fitted first.')
+        assert hasattr(
+            self, "fitted_models_"
+        ), "ERROR: GapEncoder must be fitted first."
         # Generate prefixes
-        if isinstance(col_names, str) and col_names == 'auto':
-            if hasattr(self, 'column_names_'):  # Use column names
-                prefixes = [
-                    '%s: ' % col for col in self.column_names_
-                ]
+        if isinstance(col_names, str) and col_names == "auto":
+            if hasattr(self, "column_names_"):  # Use column names
+                prefixes = ["%s: " % col for col in self.column_names_]
             else:  # Use 'col1: ', ... 'colN: ' as prefixes
-                prefixes = [
-                    'col%d: ' % i for i in range(len(self.fitted_models_))
-                ]
+                prefixes = ["col%d: " % i for i in range(len(self.fitted_models_))]
         elif col_names is None:  # Empty prefixes
-            prefixes = [''] * len(self.fitted_models_)
+            prefixes = [""] * len(self.fitted_models_)
         else:
-            prefixes = ['%s: ' % col for col in col_names]
+            prefixes = ["%s: " % col for col in col_names]
         labels = list()
         for k, enc in enumerate(self.fitted_models_):
             col_labels = enc.get_feature_names_out(n_labels, prefixes[k])
             labels.extend(col_labels)
         return labels
-    
-    def get_feature_names(self, input_features=None,
-                          col_names: List[str] = None, n_labels: int = 3
-                          ) -> List[str]:
+
+    def get_feature_names(
+        self, input_features=None, col_names: List[str] = None, n_labels: int = 3
+    ) -> List[str]:
         """
         Ensures compatibility with sklearn < 1.0.
         Use `get_feature_names_out` instead.
         """
-        if Version(sklearn_version) >= '1.0':
+        if Version(sklearn_version) >= "1.0":
             warnings.warn(
                 "Following the changes in scikit-learn 1.0, "
                 "get_feature_names is deprecated. "
@@ -872,10 +920,15 @@ def _rescale_W(W: np.array, A: np.array) -> None:
     A /= s
 
 
-def _multiplicative_update_w(Vt: np.array, W: np.array, A: np.array,
-                             B: np.array, Ht: np.array, rescale_W: bool,
-                             rho: float,
-                             ) -> Tuple[np.array, np.array, np.array]:
+def _multiplicative_update_w(
+    Vt: np.array,
+    W: np.array,
+    A: np.array,
+    B: np.array,
+    Ht: np.array,
+    rescale_W: bool,
+    rho: float,
+) -> Tuple[np.array, np.array, np.array]:
     """
     Multiplicative update step for the topics W.
     """
@@ -899,11 +952,16 @@ def _rescale_h(V: np.array, H: np.array) -> np.array:
     return H
 
 
-def _multiplicative_update_h(Vt: np.array, W: np.array, Ht: np.array,
-                             epsilon: float = 1e-3, max_iter: int = 10,
-                             rescale_W: bool = False,
-                             gamma_shape_prior: float = 1.1,
-                             gamma_scale_prior: float = 1.):
+def _multiplicative_update_h(
+    Vt: np.array,
+    W: np.array,
+    Ht: np.array,
+    epsilon: float = 1e-3,
+    max_iter: int = 10,
+    rescale_W: bool = False,
+    gamma_shape_prior: float = 1.1,
+    gamma_scale_prior: float = 1.0,
+):
     """
     Multiplicative update step for the activations H.
     """
@@ -926,14 +984,15 @@ def _multiplicative_update_h(Vt: np.array, W: np.array, Ht: np.array,
                 break
             aux = np.dot(W_WT1_, vt_ / (np.dot(ht, W_) + 1e-10))
             ht_out = ht * aux + const
-            squared_norm = np.dot(
-                ht_out - ht, ht_out - ht) / np.dot(ht, ht)
+            squared_norm = np.dot(ht_out - ht, ht_out - ht) / np.dot(ht, ht)
             ht[:] = ht_out
     return Ht
 
 
-def batch_lookup(lookup: np.array, n: int = 1,
-                 ) -> Generator[Tuple[np.array, np.array], None, None]:
+def batch_lookup(
+    lookup: np.array,
+    n: int = 1,
+) -> Generator[Tuple[np.array, np.array], None, None]:
     """
     Make batches of the lookup array.
     """
@@ -944,24 +1003,29 @@ def batch_lookup(lookup: np.array, n: int = 1,
         yield unq_indices, indices
 
 
-def get_kmeans_prototypes(X,
-                          n_prototypes: int,
-                          analyzer: Literal["word", "char", "char_wb"] = 'char',
-                          hashing_dim: int = 128,
-                          ngram_range: Tuple[int, int] = (2, 4),
-                          sparse: bool = False,
-                          sample_weight=None,
-                          random_state: Optional[Union[int, RandomState]] = None):
+def get_kmeans_prototypes(
+    X,
+    n_prototypes: int,
+    analyzer: Literal["word", "char", "char_wb"] = "char",
+    hashing_dim: int = 128,
+    ngram_range: Tuple[int, int] = (2, 4),
+    sparse: bool = False,
+    sample_weight=None,
+    random_state: Optional[Union[int, RandomState]] = None,
+):
     """
     Computes prototypes based on:
       - dimensionality reduction (via hashing n-grams)
       - k-means clustering
       - nearest neighbor
     """
-    vectorizer = HashingVectorizer(analyzer=analyzer, norm=None,
-                                   alternate_sign=False,
-                                   ngram_range=ngram_range,
-                                   n_features=hashing_dim)
+    vectorizer = HashingVectorizer(
+        analyzer=analyzer,
+        norm=None,
+        alternate_sign=False,
+        ngram_range=ngram_range,
+        n_features=hashing_dim,
+    )
     projected = vectorizer.transform(X)
     if not sparse:
         projected = projected.toarray()

--- a/dirty_cat/string_distances.py
+++ b/dirty_cat/string_distances.py
@@ -3,10 +3,8 @@ Some string distances
 """
 
 import re
-
-from typing import Tuple
 from collections import Counter
-
+from typing import Tuple
 
 # TODO vectorize these functions (accept arrays)
 
@@ -51,12 +49,12 @@ def preprocess(x: str) -> str:
     """
 
     # Preprocessing step done in ngram_similarity
-    x = f' {x} '
+    x = f" {x} "
 
     # Preprocessing step done in the CountVectorizer
     _white_spaces = re.compile(r"\s\s+")
 
-    return _white_spaces.sub(' ', x)
+    return _white_spaces.sub(" ", x)
 
 
 def get_unique_ngrams(string: str, ngram_range: Tuple[int, int]):
@@ -76,7 +74,7 @@ def get_unique_ngrams(string: str, ngram_range: Tuple[int, int]):
     set
         The set of unique n-grams of the string.
     """
-    spaces = ' '  # * (n // 2 + n % 2)
+    spaces = " "  # * (n // 2 + n % 2)
     string = spaces + " ".join(string.lower().split()) + spaces
     ngram_set = set()
     for n in range(ngram_range[0], ngram_range[1] + 1):
@@ -86,18 +84,16 @@ def get_unique_ngrams(string: str, ngram_range: Tuple[int, int]):
 
 
 def get_ngrams(string, n):
-    """ Return the set of different tri-grams in a string
-    """
+    """Return the set of different tri-grams in a string"""
     # Pure Python implementation: no numpy
-    spaces = ' '  # * (n // 2 + n % 2)
+    spaces = " "  # * (n // 2 + n % 2)
     string = spaces + " ".join(string.lower().split()) + spaces
     string_list = [string[i:] for i in range(n)]
     return list(zip(*string_list))
 
 
 def ngram_similarity(string1, string2, n, preprocess_strings=True):
-    """ n-gram similarity between two strings
-    """
+    """n-gram similarity between two strings"""
     if preprocess_strings:
         string1, string2 = preprocess(string1), preprocess(string2)
 
@@ -109,11 +105,11 @@ def ngram_similarity(string1, string2, n, preprocess_strings=True):
 
     samegrams = sum((count1 & count2).values())
     allgrams = len(ngrams1) + len(ngrams2)
-    similarity = samegrams/(allgrams - samegrams)
+    similarity = samegrams / (allgrams - samegrams)
     return similarity
 
 
-if __name__ == '__main__':
-    s1 = 'aa'
-    s2 = 'aaab'
-    print('3-gram similarity: %.3f' % ngram_similarity(s1, s2, 3))
+if __name__ == "__main__":
+    s1 = "aa"
+    s2 = "aaab"
+    print("3-gram similarity: %.3f" % ngram_similarity(s1, s2, 3))

--- a/dirty_cat/super_vectorizer.py
+++ b/dirty_cat/super_vectorizer.py
@@ -4,18 +4,17 @@ apply encoders to different types of data, without the need to manually
 categorize them beforehand, or construct complex Pipelines.
 """
 
+from typing import Dict, List, Literal, Optional, Tuple, Union
+from warnings import warn
+
 import numpy as np
 import pandas as pd
-
-from warnings import warn
-from typing import Union, Optional, List, Dict, Tuple, Literal
-
+from sklearn import __version__ as sklearn_version
 from sklearn.base import BaseEstimator, clone
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder
-from sklearn import __version__ as sklearn_version
 
-from dirty_cat import GapEncoder, DatetimeEncoder
+from dirty_cat import DatetimeEncoder, GapEncoder
 from dirty_cat.utils import Version, check_input
 
 
@@ -32,7 +31,7 @@ def _replace_missing_in_col(df: pd.Series, value: str = "missing") -> pd.Series:
     """
     dtype_name = df.dtype.name
 
-    if dtype_name == 'category' and (value not in df.cat.categories):
+    if dtype_name == "category" and (value not in df.cat.categories):
         df = df.cat.add_categories(value)
     df = df.fillna(value=value)
     return df
@@ -58,7 +57,7 @@ class SuperVectorizer(ColumnTransformer):
         the parameters `low_card_cat_transformer` and
         `high_card_cat_transformer` respectively.
 
-    low_card_cat_transformer : typing.Optional[typing.Union[sklearn.base.BaseEstimator, str]], default=None
+    low_card_cat_transformer : typing.Optional[typing.Union[sklearn.base.BaseEstimator, str]], default=None  # noqa
         Transformer used on categorical/string features with low cardinality
         (threshold is defined by `cardinality_threshold`).
         Default value None is converted to `OneHotEncoder()`.
@@ -67,7 +66,7 @@ class SuperVectorizer(ColumnTransformer):
         None to apply `remainder`, 'drop' for dropping the columns,
         or 'passthrough' to return the unencoded columns.
 
-    high_card_cat_transformer : typing.Optional[typing.Union[sklearn.base.BaseEstimator, str]], default=None
+    high_card_cat_transformer : typing.Optional[typing.Union[sklearn.base.BaseEstimator, str]], default=None  # noqa
         Transformer used on categorical/string features with high cardinality
         (threshold is defined by `cardinality_threshold`).
         Default value None is converted to `GapEncoder(n_components=30)`.
@@ -76,7 +75,7 @@ class SuperVectorizer(ColumnTransformer):
         None to apply `remainder`, 'drop' for dropping the columns,
         or 'passthrough' to return the unencoded columns.
 
-    numerical_transformer : typing.Optional[typing.Union[sklearn.base.BaseEstimator, str]], default=None
+    numerical_transformer : typing.Optional[typing.Union[sklearn.base.BaseEstimator,str]], default=None  # noqa
         Transformer used on numerical features.
         Can either be a transformer object instance (e.g. `StandardScaler()`),
         a `Pipeline` containing the preprocessing steps,
@@ -105,7 +104,7 @@ class SuperVectorizer(ColumnTransformer):
         When imputed, missing values are replaced by the string 'missing'.
         See also attribute `imputed_columns_`.
 
-    remainder : typing.Union[typing.Literal["drop", "passthrough"], sklearn.base.BaseEstimator], default='drop'
+    remainder : typing.Union[typing.Literal["drop", "passthrough"], sklearn.base.BaseEstimator], default='drop'  # noqa
         By default, only the specified columns in `transformers` are
         transformed and combined in the output, and the non-specified
         columns are dropped. (default of ``'drop'``).
@@ -143,7 +142,7 @@ class SuperVectorizer(ColumnTransformer):
     Attributes
     ----------
 
-    transformers_: typing.List[typing.Tuple[str, typing.Union[str, sklearn.base.BaseEstimator], typing.List[str]]]
+    transformers_: typing.List[typing.Tuple[str, typing.Union[str, sklearn.base.BaseEstimator], typing.List[str]]]  # noqa
         The final distribution of columns.
         List of three-tuple containing
         (1) the name of the category
@@ -172,21 +171,23 @@ class SuperVectorizer(ColumnTransformer):
     _required_parameters = []
     OptionalEstimator = Optional[Union[BaseEstimator, str]]
 
-    def __init__(self, *,
-                 cardinality_threshold: int = 40,
-                 low_card_cat_transformer: Optional[Union[BaseEstimator, str]] = None,
-                 high_card_cat_transformer: Optional[Union[BaseEstimator, str]] = None,
-                 numerical_transformer: Optional[Union[BaseEstimator, str]] = None,
-                 datetime_transformer: Optional[Union[BaseEstimator, str]] = None,
-                 auto_cast: bool = True,
-                 impute_missing: str = 'auto',
-                 # The next parameters are inherited from ColumnTransformer
-                 remainder: Union[Literal["drop", "passthrough"], BaseEstimator] = 'passthrough',
-                 sparse_threshold: float = 0.3,
-                 n_jobs: int = None,
-                 transformer_weights=None,
-                 verbose: bool = False,
-                 ):
+    def __init__(
+        self,
+        *,
+        cardinality_threshold: int = 40,
+        low_card_cat_transformer: Optional[Union[BaseEstimator, str]] = None,
+        high_card_cat_transformer: Optional[Union[BaseEstimator, str]] = None,
+        numerical_transformer: Optional[Union[BaseEstimator, str]] = None,
+        datetime_transformer: Optional[Union[BaseEstimator, str]] = None,
+        auto_cast: bool = True,
+        impute_missing: str = "auto",
+        # The next parameters are inherited from ColumnTransformer
+        remainder: Union[Literal["drop", "passthrough"], BaseEstimator] = "passthrough",
+        sparse_threshold: float = 0.3,
+        n_jobs: int = None,
+        transformer_weights=None,
+        verbose: bool = False,
+    ):
         super().__init__(transformers=[])
 
         self.cardinality_threshold = cardinality_threshold
@@ -258,32 +259,49 @@ class SuperVectorizer(ColumnTransformer):
                 X[col].fillna(value=np.nan, inplace=True)
 
         # taken from pandas.io.parsers (version 1.1.4)
-        STR_NA_VALUES = ['null', '', '1.#QNAN', '#NA', 'nan', '#N/A N/A',
-                         '-1.#QNAN', '<NA>', '-1.#IND', '-nan', 'n/a',
-                         '-NaN', '1.#IND', 'NULL', 'NA', 'N/A', '#N/A', 'NaN']
+        STR_NA_VALUES = [
+            "null",
+            "",
+            "1.#QNAN",
+            "#NA",
+            "nan",
+            "#N/A N/A",
+            "-1.#QNAN",
+            "<NA>",
+            "-1.#IND",
+            "-nan",
+            "n/a",
+            "-NaN",
+            "1.#IND",
+            "NULL",
+            "NA",
+            "N/A",
+            "#N/A",
+            "NaN",
+        ]
         X = X.replace(STR_NA_VALUES + [None, "?", "..."], np.nan)
-        X = X.replace(r'^\s+$', np.nan, regex=True)  # replace whitespaces
+        X = X.replace(r"^\s+$", np.nan, regex=True)  # replace whitespaces
 
         # Convert to the best possible data type
         for col in X.columns:
             if not pd.api.types.is_datetime64_any_dtype(X[col]):
                 # we don't want to cast datetime64
                 try:
-                    X.loc[:, col] = pd.to_numeric(X[col], errors='raise')
-                except:
+                    X.loc[:, col] = pd.to_numeric(X[col], errors="raise")
+                except (ValueError, TypeError):
                     # Only try to convert to datetime
                     # if the variable isn't numeric.
                     try:
-                        X.loc[:, col] = pd.to_datetime(X[col], errors='raise',
-                                                infer_datetime_format=True)
-                    except:
+                        X.loc[:, col] = pd.to_datetime(
+                            X[col], errors="raise", infer_datetime_format=True
+                        )
+                    except (ValueError, TypeError):
                         pass
             # Cast pandas dtypes to numpy dtypes
             # for earlier versions of sklearn
             if issubclass(X[col].dtype.__class__, ExtensionDtype):
                 try:
-                    X.loc[:, col] = X[col].astype(X[col].dtype.type,
-                                                  errors='ignore')
+                    X.loc[:, col] = X[col].astype(X[col].dtype.type, errors="ignore")
                 except (TypeError, ValueError):
                     pass
         return X
@@ -317,9 +335,11 @@ class SuperVectorizer(ColumnTransformer):
             X = self._auto_cast(X)
             self.types_ = {c: t for c, t in zip(X.columns, X.dtypes)}
         if X.shape[1] != len(self.columns_):
-            raise ValueError(f"Passed array does not match column count of "
-                             f"array seen at fit time. Got {X.shape[1]} "
-                             f"columns, expected {len(self.columns_)}")
+            raise ValueError(
+                "Passed array does not match column count of "
+                f"array seen at fit time. Got {X.shape[1]} "
+                f"columns, expected {len(self.columns_)}"
+            )
 
         # If the DataFrame does not have named columns already,
         # apply the learnt columns
@@ -377,33 +397,45 @@ class SuperVectorizer(ColumnTransformer):
         # Select columns by dtype
         numeric_columns = X.select_dtypes(
             include=[
-                'int', 'float',
-                np.float64, np.float32, np.float16,
-                np.int64, np.int32, np.int16,
-                np.uint64, np.uint32, np.uint16
-            ]).columns.to_list()
+                "int",
+                "float",
+                np.float64,
+                np.float32,
+                np.float16,
+                np.int64,
+                np.int32,
+                np.int16,
+                np.uint64,
+                np.uint32,
+                np.uint16,
+            ]
+        ).columns.to_list()
         categorical_columns = X.select_dtypes(
-            include=['string', 'object', 'category']).columns.to_list()
+            include=["string", "object", "category"]
+        ).columns.to_list()
         datetime_columns = X.select_dtypes(
-            include=['datetime', "datetimetz"]).columns.to_list()
+            include=["datetime", "datetimetz"]
+        ).columns.to_list()
 
         # Divide categorical columns by cardinality
         low_card_cat_columns = [
-            col for col in categorical_columns
+            col
+            for col in categorical_columns
             if X[col].nunique() < self.cardinality_threshold
         ]
         high_card_cat_columns = [
-            col for col in categorical_columns
+            col
+            for col in categorical_columns
             if X[col].nunique() >= self.cardinality_threshold
         ]
 
         # Next part: construct the transformers
         # Create the list of all the transformers.
         all_transformers = [
-            ('numeric', self.numerical_transformer, numeric_columns),
-            ('datetime', self.datetime_transformer_, datetime_columns),
-            ('low_card_cat', self.low_card_cat_transformer_, low_card_cat_columns),
-            ('high_card_cat', self.high_card_cat_transformer_, high_card_cat_columns),
+            ("numeric", self.numerical_transformer, numeric_columns),
+            ("datetime", self.datetime_transformer_, datetime_columns),
+            ("low_card_cat", self.low_card_cat_transformer_, low_card_cat_columns),
+            ("high_card_cat", self.high_card_cat_transformer_, high_card_cat_columns),
         ]
         # We will now filter this list, by keeping only the ones with:
         # - at least one column
@@ -415,27 +447,27 @@ class SuperVectorizer(ColumnTransformer):
                 self.transformers.append(trans)
 
         if len(self.transformers) == 0:
-            raise RuntimeError('No transformers could be generated! ')
+            raise RuntimeError("No transformers could be generated! ")
 
         self.imputed_columns_ = []
         if _has_missing_values(X):
-
-            if self.impute_missing == 'force':
+            if self.impute_missing == "force":
                 for col in X.columns:
                     # Do not impute numeric columns
                     if not pd.api.types.is_numeric_dtype(X[col]):
                         X.loc[:, col] = _replace_missing_in_col(X[col])
                         self.imputed_columns_.append(col)
 
-            elif self.impute_missing == 'skip':
+            elif self.impute_missing == "skip":
                 pass
 
-            elif self.impute_missing == 'auto':
+            elif self.impute_missing == "auto":
                 for name, trans, cols in all_transformers:
                     impute: bool = False
 
-                    if isinstance(trans, OneHotEncoder) \
-                            and Version(sklearn_version) < Version('0.24'):
+                    if isinstance(trans, OneHotEncoder) and Version(
+                        sklearn_version
+                    ) < Version("0.24"):
                         impute = True
 
                     if impute:
@@ -448,7 +480,7 @@ class SuperVectorizer(ColumnTransformer):
             else:
                 raise ValueError(
                     "Invalid value for `impute_missing`, expected any of "
-                    f"{{'auto', 'force', 'skip'}}, "
+                    "{'auto', 'force', 'skip'}, "
                     f"got {self.impute_missing!r}. "
                 )
 
@@ -459,8 +491,7 @@ class SuperVectorizer(ColumnTransformer):
             X = self._auto_cast(X)
 
         if self.verbose:
-            print(f'[SuperVectorizer] Assigned transformers: '
-                  f'{self.transformers}')
+            print(f"[SuperVectorizer] Assigned transformers: {self.transformers}")
 
         check_input(X)
 
@@ -474,9 +505,7 @@ class SuperVectorizer(ColumnTransformer):
             if name == "remainder" and len(cols) < 20:
                 # In this case, "cols" is a list of ints (the indices)
                 cols: List[int]
-                self.transformers_[i] = (
-                    name, enc, [self.columns_[j] for j in cols]
-                )
+                self.transformers_[i] = (name, enc, [self.columns_[j] for j in cols])
 
         return res
 
@@ -491,21 +520,21 @@ class SuperVectorizer(ColumnTransformer):
         typing.List[str]
             Feature names.
         """
-        if Version(sklearn_version) < Version('0.23'):
+        if Version(sklearn_version) < Version("0.23"):
             try:
-                if Version(sklearn_version) < Version('1.0'):
+                if Version(sklearn_version) < Version("1.0"):
                     ct_feature_names = super().get_feature_names()
                 else:
                     ct_feature_names = super().get_feature_names_out()
             except NotImplementedError:
                 raise NotImplementedError(
-                    'Prior to sklearn 0.23, get_feature_names with '
+                    "Prior to sklearn 0.23, get_feature_names with "
                     '"passthrough" is unsupported. To use the method, '
                     'either make sure there is no "passthrough" in the '
-                    'transformers, or update your copy of scikit-learn. '
+                    "transformers, or update your copy of scikit-learn. "
                 )
         else:
-            if Version(sklearn_version) < Version('1.0'):
+            if Version(sklearn_version) < Version("1.0"):
                 ct_feature_names = super().get_feature_names()
             else:
                 ct_feature_names = super().get_feature_names_out()
@@ -513,24 +542,24 @@ class SuperVectorizer(ColumnTransformer):
 
         for name, trans, cols, _ in self._iter(fitted=True):
             if isinstance(trans, str):
-                if trans == 'drop':
+                if trans == "drop":
                     continue
-                elif trans == 'passthrough':
+                elif trans == "passthrough":
                     if all(isinstance(col, int) for col in cols):
                         cols = [self.columns_[i] for i in cols]
                     all_trans_feature_names.extend(cols)
                 continue
-            if not hasattr(trans, 'get_feature_names'):
+            if not hasattr(trans, "get_feature_names"):
                 all_trans_feature_names.extend(cols)
             else:
-                if Version(sklearn_version) < Version('1.0'):
+                if Version(sklearn_version) < Version("1.0"):
                     trans_feature_names = trans.get_feature_names(cols)
                 else:
                     trans_feature_names = trans.get_feature_names_out(cols)
                 all_trans_feature_names.extend(trans_feature_names)
 
         if len(ct_feature_names) != len(all_trans_feature_names):
-            warn('Could not extract clean feature names; returning defaults. ')
+            warn("Could not extract clean feature names; returning defaults. ")
             return ct_feature_names
 
         return all_trans_feature_names
@@ -540,7 +569,7 @@ class SuperVectorizer(ColumnTransformer):
         Ensures compatibility with sklearn < 1.0.
         Use `get_feature_names_out` instead.
         """
-        if Version(sklearn_version) >= '1.0':
+        if Version(sklearn_version) >= "1.0":
             warn(
                 "Following the changes in scikit-learn 1.0, "
                 "get_feature_names is deprecated. "

--- a/dirty_cat/target_encoder.py
+++ b/dirty_cat/target_encoder.py
@@ -1,13 +1,13 @@
 import collections
+from typing import Dict, List, Literal, Union
+
 import numpy as np
-
-from typing import List, Dict, Literal, Union
-
-from sklearn.preprocessing import LabelEncoder
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_array
 from sklearn.utils.fixes import _object_dtype_isnan
 from sklearn.utils.validation import check_is_fitted
+
 from dirty_cat.utils import check_input
 
 
@@ -27,7 +27,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    categories : typing.Union[typing.Literal["auto"], typing.List[typing.List[typing.Union[str, int]]]
+    categories : typing.Union[typing.Literal["auto"], typing.List[typing.List[typing.Union[str, int]]]  # noqa
         Categories (unique values) per feature:
         - 'auto' : Determine categories automatically from the training data.
         - list : ``categories[i]`` holds the categories expected in the i-th
@@ -71,12 +71,14 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
     categories_: List[np.array]
     n_: int
 
-    def __init__(self,
-                 categories: Union[Literal["auto"], List[Union[List[str], np.array]]] = 'auto',
-                 clf_type: Literal["regression", "binary-clf", "multiclass-clf"] = 'binary-clf',
-                 dtype: type = np.float64,
-                 handle_unknown: Literal["error", "ignore"] = 'error',
-                 handle_missing: Literal["error", ""] = ''):
+    def __init__(
+        self,
+        categories: Union[Literal["auto"], List[Union[List[str], np.array]]] = "auto",
+        clf_type: Literal["regression", "binary-clf", "multiclass-clf"] = "binary-clf",
+        dtype: type = np.float64,
+        handle_unknown: Literal["error", "ignore"] = "error",
+        handle_missing: Literal["error", ""] = "",
+    ):
         self.categories = categories
         self.dtype = dtype
         self.clf_type = clf_type
@@ -107,26 +109,26 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         """
         X = check_input(X)
         self.n_features_in_ = X.shape[1]
-        if self.handle_missing not in ['error', '']:
+        if self.handle_missing not in ["error", ""]:
             raise ValueError(
                 f"Got handle_missing={self.handle_missing!r}, but expected "
-                f"any of {{'error', ''}}. "
+                "any of {'error', ''}. "
             )
-        if hasattr(X, 'iloc') and X.isna().values.any():
-            if self.handle_missing == 'error':
-                    raise ValueError(
-                        "Found missing values in input data; set "
-                        "handle_missing='' to encode with missing values. "
-                    )
+        if hasattr(X, "iloc") and X.isna().values.any():
+            if self.handle_missing == "error":
+                raise ValueError(
+                    "Found missing values in input data; set "
+                    "handle_missing='' to encode with missing values. "
+                )
             else:
                 X = X.fillna(self.handle_missing)
-        elif not hasattr(X, 'dtype') and isinstance(X, list):
+        elif not hasattr(X, "dtype") and isinstance(X, list):
             X = np.asarray(X, dtype=object)
 
-        if hasattr(X, 'dtype'):
+        if hasattr(X, "dtype"):
             mask = _object_dtype_isnan(X)
-            if X.dtype.kind == 'O' and mask.any():
-                if self.handle_missing == 'error':
+            if X.dtype.kind == "O" and mask.any():
+                if self.handle_missing == "error":
                     raise ValueError(
                         "Found missing values in input data; set "
                         "handle_missing='' to encode with missing values. "
@@ -134,21 +136,19 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
                 else:
                     X[mask] = self.handle_missing
 
-        if self.handle_unknown not in ['error', 'ignore']:
+        if self.handle_unknown not in ["error", "ignore"]:
             raise ValueError(
-                f'Got handle_unknown={self.handle_unknown!r}, but expected'
-                f'any of {{"error", "ignore"}}. '
+                f"Got handle_unknown={self.handle_unknown!r}, but expected"
+                'any of {"error", "ignore"}. '
             )
 
-        if self.categories != 'auto':
+        if self.categories != "auto":
             for cats in self.categories:
                 if not np.all(np.sort(cats) == np.array(cats)):
-                    raise ValueError(
-                        "Unsorted categories are not yet supported. "
-                    )
+                    raise ValueError("Unsorted categories are not yet supported. ")
 
         X_temp = check_array(X, dtype=None)
-        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, np.str_):
+        if not hasattr(X, "dtype") and np.issubdtype(X_temp.dtype, np.str_):
             X = check_array(X, dtype=np.object)
         else:
             X = X_temp
@@ -161,38 +161,42 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         for j in range(n_features):
             le = self._label_encoders_[j]
             Xj = X[:, j]
-            if self.categories == 'auto':
+            if self.categories == "auto":
                 le.fit(Xj)
             else:
-                if self.handle_unknown == 'error':
+                if self.handle_unknown == "error":
                     valid_mask = np.in1d(Xj, self.categories[j])
                     if not np.all(valid_mask):
                         diff = np.unique(Xj[~valid_mask])
                         raise ValueError(
-                            f"Found unknown categories {diff} in column {j}"
-                            f" during fit"
+                            f"Found unknown categories {diff} in column {j} during fit"
                         )
                 le.classes_ = np.array(self.categories[j])
 
         self.categories_ = [le.classes_ for le in self._label_encoders_]
         self.n_ = len(y)
-        if self.clf_type in ['binary-clf', 'regression']:
-            self.Eyx_ = [{cat: np.mean(y[X[:, j] == cat])
-                          for cat in self.categories_[j]}
-                         for j in range(len(self.categories_))]
+        if self.clf_type in ["binary-clf", "regression"]:
+            self.Eyx_ = [
+                {cat: np.mean(y[X[:, j] == cat]) for cat in self.categories_[j]}
+                for j in range(len(self.categories_))
+            ]
             self.Ey_ = np.mean(y)
-            self.counter_ = {j: collections.Counter(X[:, j])
-                             for j in range(n_features)}
-        if self.clf_type in ['multiclass-clf']:
+            self.counter_ = {j: collections.Counter(X[:, j]) for j in range(n_features)}
+        if self.clf_type in ["multiclass-clf"]:
             self.classes_ = np.unique(y)
 
-            self.Eyx_ = {c: [{cat: np.mean((y == c)[X[:, j] == cat])
-                              for cat in self.categories_[j]}
-                             for j in range(len(self.categories_))]
-                         for c in self.classes_}
+            self.Eyx_ = {
+                c: [
+                    {
+                        cat: np.mean((y == c)[X[:, j] == cat])
+                        for cat in self.categories_[j]
+                    }
+                    for j in range(len(self.categories_))
+                ]
+                for c in self.classes_
+            }
             self.Ey_ = {c: np.mean(y == c) for c in self.classes_}
-            self.counter_ = {j: collections.Counter(X[:, j])
-                             for j in range(n_features)}
+            self.counter_ = {j: collections.Counter(X[:, j]) for j in range(n_features)}
         self.k_ = {j: len(self.counter_[j]) for j in self.counter_}
         return self
 
@@ -203,7 +207,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : array-like, shape [n_samples, n_features_new]
-            The data to encode. 
+            The data to encode.
 
         Returns
         -------
@@ -215,33 +219,33 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         if X.shape[1] != self.n_features_in_:
             raise ValueError(
                 f"The number of features in the input data ({X.shape[1]}) "
-                f"does not match the number of features "
+                "does not match the number of features "
                 f"seen during fit ({self.n_features_in_})."
             )
-        if hasattr(X, 'iloc') and X.isna().values.any():
-            if self.handle_missing == 'error':
-                    raise ValueError(
-                        "Found missing values in input data; set "
-                        "handle_missing='' to encode with missing values. "
-                    )
-            if self.handle_missing != 'error':
+        if hasattr(X, "iloc") and X.isna().values.any():
+            if self.handle_missing == "error":
+                raise ValueError(
+                    "Found missing values in input data; set "
+                    "handle_missing='' to encode with missing values. "
+                )
+            if self.handle_missing != "error":
                 X = X.fillna(self.handle_missing)
-        elif not hasattr(X, 'dtype') and isinstance(X, list):
+        elif not hasattr(X, "dtype") and isinstance(X, list):
             X = np.asarray(X, dtype=object)
 
-        if hasattr(X, 'dtype'):
+        if hasattr(X, "dtype"):
             mask = _object_dtype_isnan(X)
-            if X.dtype.kind == 'O' and mask.any():
-                if self.handle_missing == 'error':
+            if X.dtype.kind == "O" and mask.any():
+                if self.handle_missing == "error":
                     raise ValueError(
                         "Found missing values in input data; set "
                         "handle_missing='' to encode with missing values. "
                     )
-                if self.handle_missing != 'error':
+                if self.handle_missing != "error":
                     X[mask] = self.handle_missing
 
         X_temp = check_array(X, dtype=None)
-        if not hasattr(X, 'dtype') and np.issubdtype(X_temp.dtype, np.str_):
+        if not hasattr(X, "dtype") and np.issubdtype(X_temp.dtype, np.str_):
             X = check_array(X, dtype=np.object)
         else:
             X = X_temp
@@ -255,11 +259,11 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
             valid_mask = np.in1d(Xi, self.categories_[i])
 
             if not np.all(valid_mask):
-                if self.handle_unknown == 'error':
+                if self.handle_unknown == "error":
                     diff = np.unique(X[~valid_mask, i])
                     raise ValueError(
                         f"Found unknown categories {diff} in column {i} "
-                        f"during transform. "
+                        "during transform. "
                     )
                 else:
                     # Set the problematic rows to an acceptable value and
@@ -275,31 +279,30 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         for j, cats in enumerate(self.categories_):
             unqX = np.unique(X[:, j])
             encoder = {x: 0 for x in unqX}
-            if self.clf_type in ['binary-clf', 'regression']:
+            if self.clf_type in ["binary-clf", "regression"]:
                 for x in unqX:
                     if x not in cats:
                         Eyx = 0
                     else:
                         Eyx = self.Eyx_[j][x]
-                    lambda_n = lambda_(self.counter_[j][x], self.n_/self.k_[j])
-                    encoder[x] = lambda_n*Eyx + (1 - lambda_n)*self.Ey_
+                    lambda_n = lambda_(self.counter_[j][x], self.n_ / self.k_[j])
+                    encoder[x] = lambda_n * Eyx + (1 - lambda_n) * self.Ey_
                 x_out = np.zeros((len(X[:, j]), 1))
                 for i, x in enumerate(X[:, j]):
                     x_out[i, 0] = encoder[x]
                 out.append(x_out.reshape(-1, 1))
-            if self.clf_type == 'multiclass-clf':
+            if self.clf_type == "multiclass-clf":
                 x_out = np.zeros((len(X[:, j]), len(self.classes_)))
                 lambda_n = {x: 0 for x in unqX}
                 for x in unqX:
-                    lambda_n[x] = lambda_(self.counter_[j][x], self.n_/self.k_[j])
+                    lambda_n[x] = lambda_(self.counter_[j][x], self.n_ / self.k_[j])
                 for k, c in enumerate(np.unique(self.classes_)):
                     for x in unqX:
                         if x not in cats:
                             Eyx = 0
                         else:
                             Eyx = self.Eyx_[c][j][x]
-                        encoder[x] = lambda_n[x]*Eyx + \
-                            (1 - lambda_n[x])*self.Ey_[c]
+                        encoder[x] = lambda_n[x] * Eyx + (1 - lambda_n[x]) * self.Ey_[c]
                     for i, x in enumerate(X[:, j]):
                         x_out[i, k] = encoder[x]
                 out.append(x_out)

--- a/dirty_cat/test/test_datetime_encoder.py
+++ b/dirty_cat/test/test_datetime_encoder.py
@@ -1,41 +1,90 @@
 import numpy as np
 import pandas as pd
+
 from dirty_cat.datetime_encoder import DatetimeEncoder
 
 
 def get_date_array() -> np.array:
-    return np.array([pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
-                     pd.to_datetime(["2021-02-03", "2020-02-04", "2021-02-05"]),
-                     pd.to_datetime(["2022-01-01", "2020-12-25", "2022-01-03"]),
-                     pd.to_datetime(["2023-02-03", "2020-02-04", "2023-02-05"])])
+    return np.array(
+        [
+            pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03"]),
+            pd.to_datetime(["2021-02-03", "2020-02-04", "2021-02-05"]),
+            pd.to_datetime(["2022-01-01", "2020-12-25", "2022-01-03"]),
+            pd.to_datetime(["2023-02-03", "2020-02-04", "2023-02-05"]),
+        ]
+    )
 
 
 def get_constant_date_array() -> np.array:
-    return np.array([pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
-                     pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
-                     pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
-                     pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"])])
+    return np.array(
+        [
+            pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
+            pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
+            pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
+            pd.to_datetime(["2020-01-01", "2020-02-04", "2021-02-05"]),
+        ]
+    )
 
 
 def get_datetime_array() -> np.array:
-    return np.array([pd.to_datetime(["2020-01-01 10:12:01", "2020-01-02 10:23:00", "2020-01-03 10:00:00"]),
-                     pd.to_datetime(["2021-02-03 12:45:23", "2020-02-04 22:12:00", "2021-02-05 12:00:00"]),
-                     pd.to_datetime(["2022-01-01 23:23:43", "2020-12-25 11:12:00", "2022-01-03 11:00:00"]),
-                     pd.to_datetime(["2023-02-03 11:12:12", "2020-02-04 08:32:00", "2023-02-05 23:00:00"])])
+    return np.array(
+        [
+            pd.to_datetime(
+                ["2020-01-01 10:12:01", "2020-01-02 10:23:00", "2020-01-03 10:00:00"]
+            ),
+            pd.to_datetime(
+                ["2021-02-03 12:45:23", "2020-02-04 22:12:00", "2021-02-05 12:00:00"]
+            ),
+            pd.to_datetime(
+                ["2022-01-01 23:23:43", "2020-12-25 11:12:00", "2022-01-03 11:00:00"]
+            ),
+            pd.to_datetime(
+                ["2023-02-03 11:12:12", "2020-02-04 08:32:00", "2023-02-05 23:00:00"]
+            ),
+        ]
+    )
 
 
 def get_dirty_datetime_array() -> np.array:
-    return np.array([np.array(pd.to_datetime(["2020-01-01 10:12:01", "2020-01-02 10:23:00", "2020-01-03 10:00:00"])),
-                     np.array(pd.to_datetime([np.nan, "2020-02-04 22:12:00", "2021-02-05 12:00:00"])),
-                     np.array(pd.to_datetime(["2022-01-01 23:23:43", "2020-12-25 11:12:00", pd.NaT])),
-                     np.array(pd.to_datetime(["2023-02-03 11:12:12", "2020-02-04 08:32:00", "2023-02-05 23:00:00"]))])
+    return np.array(
+        [
+            np.array(
+                pd.to_datetime(
+                    [
+                        "2020-01-01 10:12:01",
+                        "2020-01-02 10:23:00",
+                        "2020-01-03 10:00:00",
+                    ]
+                )
+            ),
+            np.array(
+                pd.to_datetime([np.nan, "2020-02-04 22:12:00", "2021-02-05 12:00:00"])
+            ),
+            np.array(
+                pd.to_datetime(["2022-01-01 23:23:43", "2020-12-25 11:12:00", pd.NaT])
+            ),
+            np.array(
+                pd.to_datetime(
+                    [
+                        "2023-02-03 11:12:12",
+                        "2020-02-04 08:32:00",
+                        "2023-02-05 23:00:00",
+                    ]
+                )
+            ),
+        ]
+    )
 
 
 def get_datetime_with_TZ_array() -> pd.DataFrame:
-    res = pd.DataFrame([pd.to_datetime(["2020-01-01 10:12:01"]),
-                        pd.to_datetime(["2021-02-03 12:45:23"]),
-                        pd.to_datetime(["2022-01-01 23:23:43"]),
-                        pd.to_datetime(["2023-02-03 11:12:12"])])
+    res = pd.DataFrame(
+        [
+            pd.to_datetime(["2020-01-01 10:12:01"]),
+            pd.to_datetime(["2021-02-03 12:45:23"]),
+            pd.to_datetime(["2022-01-01 23:23:43"]),
+            pd.to_datetime(["2023-02-03 11:12:12"]),
+        ]
+    )
     for col in res.columns:
         res[col] = pd.DatetimeIndex(res[col]).tz_localize("Asia/Kolkata")
     return res
@@ -46,9 +95,11 @@ def test_fit() -> None:
     X = get_date_array()
     enc = DatetimeEncoder()
     expected_to_extract = ["year", "month", "day", "hour"]
-    expected_features_per_column_ = {0: ["year", "month", "day"],
-                                     1: ["month", "day"],
-                                     2: ["year", "month", "day"]}
+    expected_features_per_column_ = {
+        0: ["year", "month", "day"],
+        1: ["month", "day"],
+        2: ["year", "month", "day"],
+    }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
@@ -56,9 +107,11 @@ def test_fit() -> None:
     X = get_date_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_to_extract = ["year", "month", "day", "hour", "dayofweek"]
-    expected_features_per_column_ = {0: ["year", "month", "day", "dayofweek"],
-                                     1: ["month", "day", "dayofweek"],
-                                     2: ["year", "month", "day", "dayofweek"]}
+    expected_features_per_column_ = {
+        0: ["year", "month", "day", "dayofweek"],
+        1: ["month", "day", "dayofweek"],
+        2: ["year", "month", "day", "dayofweek"],
+    }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
@@ -70,7 +123,7 @@ def test_fit() -> None:
     expected_features_per_column_ = {
         0: ["year", "month", "day", "hour", "dayofweek", "total_time"],
         1: ["month", "day", "hour", "dayofweek", "total_time"],
-        2: ["year", "month", "day", "hour", "dayofweek"]
+        2: ["year", "month", "day", "hour", "dayofweek"],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
@@ -82,7 +135,7 @@ def test_fit() -> None:
     expected_features_per_column_ = {
         0: ["year", "month", "day", "hour", "minute", "total_time"],
         1: ["month", "day", "hour", "minute"],
-        2: ["year", "month", "day", "hour"]
+        2: ["year", "month", "day", "hour"],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
@@ -95,7 +148,7 @@ def test_fit() -> None:
     expected_features_per_column_ = {
         0: ["year", "month", "day", "hour", "total_time"],
         1: ["month", "day", "hour", "total_time"],
-        2: ["year", "month", "day", "hour"]
+        2: ["year", "month", "day", "hour"],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
@@ -105,8 +158,7 @@ def test_fit() -> None:
     X = get_datetime_with_TZ_array()
     enc = DatetimeEncoder()
     expected_to_extract = ["year", "month", "day", "hour"]
-    expected_features_per_column_ = {0: ["year", "month", "day",
-                                         "hour", "total_time"]}
+    expected_features_per_column_ = {0: ["year", "month", "day", "hour", "total_time"]}
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
@@ -116,9 +168,22 @@ def test_fit() -> None:
     X = get_datetime_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_feature_names = [
-        "0_year", "0_month", "0_day", "0_hour", "0_dayofweek", "0_total_time",
-        "1_month", "1_day", "1_hour", "1_dayofweek", "1_total_time",
-        "2_year", "2_month", "2_day", "2_hour", "2_dayofweek"
+        "0_year",
+        "0_month",
+        "0_day",
+        "0_hour",
+        "0_dayofweek",
+        "0_total_time",
+        "1_month",
+        "1_day",
+        "1_hour",
+        "1_dayofweek",
+        "1_total_time",
+        "2_year",
+        "2_month",
+        "2_day",
+        "2_hour",
+        "2_dayofweek",
     ]
     enc.fit(X)
     assert enc.get_feature_names_out() == expected_feature_names
@@ -129,9 +194,22 @@ def test_fit() -> None:
     X.columns = ["col1", "col2", "col3"]
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_feature_names = [
-        "col1_year", "col1_month", "col1_day", "col1_hour", "col1_dayofweek", "col1_total_time",
-        "col2_month", "col2_day", "col2_hour", "col2_dayofweek", "col2_total_time",
-        "col3_year", "col3_month", "col3_day", "col3_hour", "col3_dayofweek"
+        "col1_year",
+        "col1_month",
+        "col1_day",
+        "col1_hour",
+        "col1_dayofweek",
+        "col1_total_time",
+        "col2_month",
+        "col2_day",
+        "col2_hour",
+        "col2_dayofweek",
+        "col2_total_time",
+        "col3_year",
+        "col3_month",
+        "col3_day",
+        "col3_hour",
+        "col3_dayofweek",
     ]
     enc.fit(X)
     assert enc.get_feature_names_out() == expected_feature_names
@@ -141,26 +219,38 @@ def test_transform():
     # Dates
     X = get_date_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
-    expected_result = np.array([[2020, 1, 1, 2, 1, 2, 3, 2020, 1, 3, 4],
-                                [2021, 2, 3, 2, 2, 4, 1, 2021, 2, 5, 4],
-                                [2022, 1, 1, 5, 12, 25, 4, 2022, 1, 3, 0],
-                                [2023, 2, 3, 4, 2, 4, 1, 2023, 2, 5, 6]])
+    expected_result = np.array(
+        [
+            [2020, 1, 1, 2, 1, 2, 3, 2020, 1, 3, 4],
+            [2021, 2, 3, 2, 2, 4, 1, 2021, 2, 5, 4],
+            [2022, 1, 1, 5, 12, 25, 4, 2022, 1, 3, 0],
+            [2023, 2, 3, 4, 2, 4, 1, 2023, 2, 5, 6],
+        ]
+    )
     enc.fit(X)
     assert np.allclose(enc.transform(X), expected_result, equal_nan=True)
 
     enc = DatetimeEncoder(add_day_of_the_week=False)
-    expected_result = np.array([[2020, 1, 1, 1, 2, 2020, 1, 3],
-                                [2021, 2, 3, 2, 4, 2021, 2, 5],
-                                [2022, 1, 1, 12, 25, 2022, 1, 3],
-                                [2023, 2, 3, 2, 4, 2023, 2, 5]])
+    expected_result = np.array(
+        [
+            [2020, 1, 1, 1, 2, 2020, 1, 3],
+            [2021, 2, 3, 2, 4, 2021, 2, 5],
+            [2022, 1, 1, 12, 25, 2022, 1, 3],
+            [2023, 2, 3, 2, 4, 2023, 2, 5],
+        ]
+    )
     enc.fit(X)
     assert np.allclose(enc.transform(X), expected_result, equal_nan=True)
 
     enc = DatetimeEncoder(add_day_of_the_week=True)
-    expected_result = np.array([[2020, 1, 1, 2, 1, 2, 3, 2020, 1, 3, 4],
-                                [2021, 2, 3, 2, 2, 4, 1, 2021, 2, 5, 4],
-                                [2022, 1, 1, 5, 12, 25, 4, 2022, 1, 3, 0],
-                                [2023, 2, 3, 4, 2, 4, 1, 2023, 2, 5, 6]])
+    expected_result = np.array(
+        [
+            [2020, 1, 1, 2, 1, 2, 3, 2020, 1, 3, 4],
+            [2021, 2, 3, 2, 2, 4, 1, 2021, 2, 5, 4],
+            [2022, 1, 1, 5, 12, 25, 4, 2022, 1, 3, 0],
+            [2023, 2, 3, 4, 2, 4, 1, 2023, 2, 5, 6],
+        ]
+    )
     enc.fit(X)
     assert np.allclose(enc.transform(X), expected_result, equal_nan=True)
 
@@ -168,29 +258,42 @@ def test_transform():
     X = get_datetime_array()[:, 0].reshape(-1, 1)
     enc = DatetimeEncoder(add_day_of_the_week=True)
     # Check that the "total_time" feature is working
-    expected_result = np.array([[2020, 1, 1, 10, 2, 0],
-                                [2021, 2, 3, 12, 2, 0],
-                                [2022, 1, 1, 23, 5, 0],
-                                [2023, 2, 3, 11, 4, 0]]).astype(np.float64)
+    expected_result = np.array(
+        [
+            [2020, 1, 1, 10, 2, 0],
+            [2021, 2, 3, 12, 2, 0],
+            [2022, 1, 1, 23, 5, 0],
+            [2023, 2, 3, 11, 4, 0],
+        ]
+    ).astype(np.float64)
     # Time from epochs in seconds
-    expected_result[:, 5] = (X.astype('int64')//1e9).astype(np.float64).reshape(-1)
+    expected_result[:, 5] = (X.astype("int64") // 1e9).astype(np.float64).reshape(-1)
 
     enc.fit(X)
     X_trans = enc.transform(X)
     assert np.allclose(X_trans, expected_result, equal_nan=True)
 
     # Check if we find back the date from the time to epoch
-    assert ((pd.to_datetime(X_trans[:, 5], unit="s") - pd.to_datetime(X.reshape(-1))).total_seconds() == 0).all()
+    assert (
+        (
+            pd.to_datetime(X_trans[:, 5], unit="s") - pd.to_datetime(X.reshape(-1))
+        ).total_seconds()
+        == 0
+    ).all()
 
     # Dirty datetimes
     X = get_dirty_datetime_array()[:, 0].reshape(-1, 1)
     enc = DatetimeEncoder(add_day_of_the_week=True)
-    expected_result = np.array([[2020, 1, 1, 10, 2, 0],
-                                [np.nan] * 6,
-                                [2022, 1, 1, 23, 5, 0],
-                                [2023, 2, 3, 11, 4, 0]])
+    expected_result = np.array(
+        [
+            [2020, 1, 1, 10, 2, 0],
+            [np.nan] * 6,
+            [2022, 1, 1, 23, 5, 0],
+            [2023, 2, 3, 11, 4, 0],
+        ]
+    )
     # Time from epochs in seconds
-    expected_result[:, 5] = (X.astype('int64')//1e9).astype(np.float64).reshape(-1)
+    expected_result[:, 5] = (X.astype("int64") // 1e9).astype(np.float64).reshape(-1)
     expected_result[1, 5] = np.nan
     enc.fit(X)
     X_trans = enc.transform(X)
@@ -203,23 +306,34 @@ def test_transform():
     # seconds between epoch time and the time of the date.
     X = get_datetime_with_TZ_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
-    expected_result = np.array([[2020, 1, 1, 10, 2, 0],
-                                [2021, 2, 3, 12, 2, 0],
-                                [2022, 1, 1, 23, 5, 0],
-                                [2023, 2, 3, 11, 4, 0]]).astype(np.float64)
+    expected_result = np.array(
+        [
+            [2020, 1, 1, 10, 2, 0],
+            [2021, 2, 3, 12, 2, 0],
+            [2022, 1, 1, 23, 5, 0],
+            [2023, 2, 3, 11, 4, 0],
+        ]
+    ).astype(np.float64)
     # Time from epochs in seconds
-    expected_result[:, 5] = (X.iloc[:, 0].view(dtype='int64')//1e9).astype(np.float64).to_numpy().reshape(-1)
+    expected_result[:, 5] = (
+        (X.iloc[:, 0].view(dtype="int64") // 1e9)
+        .astype(np.float64)
+        .to_numpy()
+        .reshape(-1)
+    )
     enc.fit(X)
     X_trans = enc.transform(X)
     assert np.allclose(X_trans, expected_result, equal_nan=True)
 
     # Check if we find back the date from the time to epoch
     assert (
-            (
-                pd.to_datetime(X_trans[:, 5], unit="s")
-                .tz_localize("utc")
-                .tz_convert(X.iloc[:, 0][0].tz) - pd.DatetimeIndex(X.iloc[:, 0])
-            ).total_seconds() == 0
+        (
+            pd.to_datetime(X_trans[:, 5], unit="s")
+            .tz_localize("utc")
+            .tz_convert(X.iloc[:, 0][0].tz)
+            - pd.DatetimeIndex(X.iloc[:, 0])
+        ).total_seconds()
+        == 0
     ).all()
 
     # Check if it's working when the date is constant

--- a/dirty_cat/test/test_fast_hash.py
+++ b/dirty_cat/test/test_fast_hash.py
@@ -1,9 +1,9 @@
-from dirty_cat.fast_hash import ngram_min_hash
 from sklearn.datasets import fetch_20newsgroups
+
+from dirty_cat.fast_hash import ngram_min_hash
 
 
 def test_fast_hash():
-
     data = fetch_20newsgroups()
     a = data.data[0]
 
@@ -12,11 +12,11 @@ def test_fast_hash():
     assert min_hash == min_hash2
 
     list_min_hash = [ngram_min_hash(a, seed=seed) for seed in range(50)]
-    assert len(set(list_min_hash)) > 45, 'Too many hash collisions'
+    assert len(set(list_min_hash)) > 45, "Too many hash collisions"
 
     min_hash4 = ngram_min_hash(a, seed=0, return_minmax=True)
     assert len(min_hash4) == 2
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     test_fast_hash()

--- a/dirty_cat/test/test_gap_encoder.py
+++ b/dirty_cat/test/test_gap_encoder.py
@@ -1,12 +1,11 @@
-import pytest
 import numpy as np
 import pandas as pd
-
+import pytest
 from sklearn import __version__ as sklearn_version
 from sklearn.datasets import fetch_20newsgroups
 
-from dirty_cat.utils import Version
 from dirty_cat import GapEncoder
+from dirty_cat.utils import Version
 
 
 def test_analyzer():
@@ -16,45 +15,60 @@ def test_analyzer():
     """
     add_words = False
     n_samples = 70
-    X_txt = fetch_20newsgroups(subset='train')['data'][:n_samples]
+    X_txt = fetch_20newsgroups(subset="train")["data"][:n_samples]
     X = np.array([X_txt, X_txt]).T
     n_components = 10
     # Test first analyzer output:
     encoder = GapEncoder(
-        n_components=n_components, init='k-means++', analyzer='char',
-        add_words=add_words, random_state=42, rescale_W=True,
+        n_components=n_components,
+        init="k-means++",
+        analyzer="char",
+        add_words=add_words,
+        random_state=42,
+        rescale_W=True,
     )
     encoder.fit(X)
     y = encoder.transform(X)
-    
+
     # Test the other analyzer output:
     encoder = GapEncoder(
-        n_components=n_components, init='k-means++', analyzer='word',
-        add_words=add_words, random_state=42,
+        n_components=n_components,
+        init="k-means++",
+        analyzer="word",
+        add_words=add_words,
+        random_state=42,
     )
     encoder.fit(X)
     y2 = encoder.transform(X)
-    
+
     # Test inequality between the word and char analyzers output:
-    np.testing.assert_raises(AssertionError, np.testing.assert_array_equal,
-                             y, y2)
+    np.testing.assert_raises(AssertionError, np.testing.assert_array_equal, y, y2)
 
 
-@pytest.mark.parametrize("hashing, init, analyzer, add_words", [
-    (False, 'k-means++', 'word', True),
-    (True, 'random', 'char', False),
-    (True, 'k-means', 'char_wb', True)
-])
-def test_gap_encoder(hashing: bool, init: str, analyzer: str, add_words: bool,
-                     n_samples: int = 70) -> None:
-    X_txt = fetch_20newsgroups(subset='train')['data'][:n_samples]
+@pytest.mark.parametrize(
+    "hashing, init, analyzer, add_words",
+    [
+        (False, "k-means++", "word", True),
+        (True, "random", "char", False),
+        (True, "k-means", "char_wb", True),
+    ],
+)
+def test_gap_encoder(
+    hashing: bool, init: str, analyzer: str, add_words: bool, n_samples: int = 70
+) -> None:
+    X_txt = fetch_20newsgroups(subset="train")["data"][:n_samples]
     X = np.array([X_txt, X_txt]).T
     n_components = 10
     # Test output shape
     encoder = GapEncoder(
-        n_components=n_components, hashing=hashing, init=init,
-        analyzer=analyzer, add_words=add_words,
-        random_state=42, rescale_W=True)
+        n_components=n_components,
+        hashing=hashing,
+        init=init,
+        analyzer=analyzer,
+        add_words=add_words,
+        random_state=42,
+        rescale_W=True,
+    )
     encoder.fit(X)
     y = encoder.transform(X)
     assert y.shape == (n_samples, n_components * X.shape[1]), str(y.shape)
@@ -62,14 +76,17 @@ def test_gap_encoder(hashing: bool, init: str, analyzer: str, add_words: bool,
     # Test L1-norm of topics W.
     for col_enc in encoder.fitted_models_:
         l1_norm_W = np.abs(col_enc.W_).sum(axis=1)
-        np.testing.assert_array_almost_equal(
-            l1_norm_W, np.ones(n_components))
+        np.testing.assert_array_almost_equal(l1_norm_W, np.ones(n_components))
 
     # Test same seed return the same output
     encoder = GapEncoder(
-        n_components=n_components, hashing=hashing, init=init,
-        analyzer=analyzer, add_words=add_words,
-        random_state=42)
+        n_components=n_components,
+        hashing=hashing,
+        init=init,
+        analyzer=analyzer,
+        add_words=add_words,
+        random_state=42,
+    )
     encoder.fit(X)
     y2 = encoder.transform(X)
     np.testing.assert_array_equal(y, y2)
@@ -77,18 +94,18 @@ def test_gap_encoder(hashing: bool, init: str, analyzer: str, add_words: bool,
 
 def test_input_type() -> None:
     # Numpy array with one column
-    X = np.array([['alice'], ['bob']])
+    X = np.array([["alice"], ["bob"]])
     enc = GapEncoder(n_components=2, random_state=42)
     X_enc_array = enc.fit_transform(X)
     # List
-    X2 = [['alice'], ['bob']]
+    X2 = [["alice"], ["bob"]]
     enc = GapEncoder(n_components=2, random_state=42)
     X_enc_list = enc.fit_transform(X2)
     # Check if the encoded vectors are the same
     np.testing.assert_array_equal(X_enc_array, X_enc_list)
-    
+
     # Numpy array with two columns
-    X = np.array([['alice', 'charlie'], ['bob', 'delta']])
+    X = np.array([["alice", "charlie"], ["bob", "delta"]])
     enc = GapEncoder(n_components=2, random_state=42)
     X_enc_array = enc.fit_transform(X)
     # Pandas dataframe with two columns
@@ -100,7 +117,7 @@ def test_input_type() -> None:
 
 
 def test_partial_fit(n_samples=70) -> None:
-    X_txt = fetch_20newsgroups(subset='train')['data'][:n_samples]
+    X_txt = fetch_20newsgroups(subset="train")["data"][:n_samples]
     X = np.array([X_txt, X_txt]).T
     # Gap encoder with fit on one batch
     enc = GapEncoder(random_state=42, batch_size=n_samples, max_iter=1)
@@ -114,7 +131,7 @@ def test_partial_fit(n_samples=70) -> None:
 
 
 def test_get_feature_names_out(n_samples=70) -> None:
-    X_txt = fetch_20newsgroups(subset='train')['data'][:n_samples]
+    X_txt = fetch_20newsgroups(subset="train")["data"][:n_samples]
     X = np.array([X_txt, X_txt]).T
     enc = GapEncoder(random_state=42)
     enc.fit(X)
@@ -129,24 +146,25 @@ def test_get_feature_names_out(n_samples=70) -> None:
         # Check number of labels
         assert len(topic_labels) == enc.n_components * X.shape[1]
         # Test different parameters for col_names
-        topic_labels_2 = enc.get_feature_names_out(col_names='auto')
-        assert topic_labels_2[0] == 'col0: ' + topic_labels[0]
-        topic_labels_3 = enc.get_feature_names_out(col_names=['abc', 'def'])
-        assert topic_labels_3[0] == 'abc: ' + topic_labels[0]
+        topic_labels_2 = enc.get_feature_names_out(col_names="auto")
+        assert topic_labels_2[0] == "col0: " + topic_labels[0]
+        topic_labels_3 = enc.get_feature_names_out(col_names=["abc", "def"])
+        assert topic_labels_3[0] == "abc: " + topic_labels[0]
     return
 
 
 def test_overflow_error() -> None:
-    np.seterr(over='raise', divide='raise')
+    np.seterr(over="raise", divide="raise")
     r = np.random.RandomState(0)
     X = r.randint(1e5, 1e6, size=(8000, 1)).astype(str)
-    enc = GapEncoder(n_components=2, batch_size=1, min_iter=1, max_iter=1,
-                     random_state=0)
+    enc = GapEncoder(
+        n_components=2, batch_size=1, min_iter=1, max_iter=1, random_state=0
+    )
     enc.fit(X)
 
 
 def test_score(n_samples: int = 70) -> None:
-    X_txt = fetch_20newsgroups(subset='train')['data'][:n_samples]
+    X_txt = fetch_20newsgroups(subset="train")["data"][:n_samples]
     X1 = np.array(X_txt)[:, None]
     X2 = np.hstack([X1, X1])
     enc = GapEncoder(random_state=42)
@@ -158,54 +176,59 @@ def test_score(n_samples: int = 70) -> None:
     assert score_X1 * 2 == score_X2
 
 
-@pytest.mark.parametrize("missing", ['zero_impute', 'error', 'aaa'])
+@pytest.mark.parametrize("missing", ["zero_impute", "error", "aaa"])
 def test_missing_values(missing: str) -> None:
-    observations = [['alice', 'bob'], ['bob', 'alice'], ['bob', np.nan],
-                    ['alice', 'charlie'], [np.nan, 'alice']]
+    observations = [
+        ["alice", "bob"],
+        ["bob", "alice"],
+        ["bob", np.nan],
+        ["alice", "charlie"],
+        [np.nan, "alice"],
+    ]
     observations = np.array(observations, dtype=object)
     enc = GapEncoder(handle_missing=missing, n_components=3)
-    if missing == 'error':
-        with pytest.raises(ValueError,
-                           match='Input data contains missing values'):
+    if missing == "error":
+        with pytest.raises(ValueError, match="Input data contains missing values"):
             enc.fit_transform(observations)
-    elif missing == 'zero_impute':
+    elif missing == "zero_impute":
         enc.fit_transform(observations)
         enc.partial_fit(observations)
     else:
-        with pytest.raises(ValueError,
-                           match=r"handle_missing should be either "
-                                 r"'error' or 'zero_impute', got 'aaa'"):
+        with pytest.raises(
+            ValueError,
+            match=r"handle_missing should be either "
+            r"'error' or 'zero_impute', got 'aaa'",
+        ):
             enc.fit_transform(observations)
 
 
-if __name__ == '__main__':
-    
-    print('test_analyzer')
+if __name__ == "__main__":
+    print("test_analyzer")
     test_analyzer()
-    print('test_analyzer passed')
+    print("test_analyzer passed")
 
-    print('start test_gap_encoder')
-    test_gap_encoder(hashing=True, init='k-means++', analyzer='char', add_words=False)
-    print('passed')
+    print("start test_gap_encoder")
+    test_gap_encoder(hashing=True, init="k-means++", analyzer="char", add_words=False)
+    print("passed")
 
-    print('start test_input_type')
+    print("start test_input_type")
     test_input_type()
-    print('passed')
+    print("passed")
 
-    print('start test_partial_fit')
+    print("start test_partial_fit")
     test_partial_fit()
-    print('passed')
+    print("passed")
 
-    print('start test_get_feature_names_out')
+    print("start test_get_feature_names_out")
     test_get_feature_names_out()
-    print('passed')
+    print("passed")
 
-    print('start test_overflow_error')
+    print("start test_overflow_error")
     test_overflow_error()
-    print('passed')
+    print("passed")
 
-    print('start test_score')
+    print("start test_score")
     test_score()
-    print('test_score passed')
-    
-    print('Done')
+    print("test_score passed")
+
+    print("Done")

--- a/dirty_cat/test/test_similarity_encoder.py
+++ b/dirty_cat/test/test_similarity_encoder.py
@@ -1,14 +1,13 @@
+from typing import Callable, Optional
+
 import numpy as np
 import numpy.testing
 import pytest
-
-from typing import Callable, Optional
-
 from sklearn import __version__ as sklearn_version
 
-from dirty_cat.utils import Version
 from dirty_cat import similarity_encoder, string_distances
 from dirty_cat.similarity_encoder import get_kmeans_prototypes
+from dirty_cat.utils import Version
 
 
 def test_specifying_categories() -> None:
@@ -24,11 +23,12 @@ def test_specifying_categories() -> None:
     # given by this encoder are equal to the transformed observations in the
     # case of a SimilarityEncoder created with categories = 'auto'
 
-    observations = [['bar'], ['foo']]
-    categories = [['bar', 'foo']]
+    observations = [["bar"], ["foo"]]
+    categories = [["bar", "foo"]]
 
     sim_enc_with_cat = similarity_encoder.SimilarityEncoder(
-        categories=categories, ngram_range=(2, 3))
+        categories=categories, ngram_range=(2, 3)
+    )
     sim_enc_auto_cat = similarity_encoder.SimilarityEncoder(ngram_range=(2, 3))
 
     feature_matrix_with_cat = sim_enc_with_cat.fit_transform(observations)
@@ -38,11 +38,12 @@ def test_specifying_categories() -> None:
 
 
 def test_fast_ngram_similarity() -> None:
-    vocabulary = [['bar', 'foo']]
-    observations = [['foo'], ['baz']]
+    vocabulary = [["bar", "foo"]]
+    observations = [["foo"], ["baz"]]
 
     sim_enc = similarity_encoder.SimilarityEncoder(
-        ngram_range=(2, 2), categories=vocabulary)
+        ngram_range=(2, 2), categories=vocabulary
+    )
 
     sim_enc.fit(observations)
     feature_matrix = sim_enc.transform(observations, fast=False)
@@ -52,25 +53,28 @@ def test_fast_ngram_similarity() -> None:
 
 
 def _test_missing_values(input_type, missing):
-    observations = [['a', 'b'], ['b', 'a'], ['b', np.nan],
-                    ['a', 'c'], [np.nan, 'a']]
-    encoded = np.array([[0., 1., 0., 0., 0., 1., 0.],
-                        [0., 0., 1., 0., 1., 0., 0.],
-                        [0., 0., 1., 0., 0., 0., 0.],
-                        [0., 1., 0., 0., 0., 0., 1.],
-                        [0., 0., 0., 0., 1., 0., 0.]])
+    observations = [["a", "b"], ["b", "a"], ["b", np.nan], ["a", "c"], [np.nan, "a"]]
+    encoded = np.array(
+        [
+            [0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        ]
+    )
 
-    if input_type == 'numpy':
+    if input_type == "numpy":
         observations = np.array(observations, dtype=object)
-    elif input_type == 'pandas':
+    elif input_type == "pandas":
         pd = pytest.importorskip("pandas")
         observations = pd.DataFrame(observations)
 
     sim_enc = similarity_encoder.SimilarityEncoder(handle_missing=missing)
-    if missing == 'error':
+    if missing == "error":
         with pytest.raises(ValueError, match=r"Found missing values in input"):
             sim_enc.fit_transform(observations)
-    elif missing == '':
+    elif missing == "":
         ans = sim_enc.fit_transform(observations)
         assert np.allclose(encoded, ans)
     else:
@@ -80,43 +84,57 @@ def _test_missing_values(input_type, missing):
 
 
 def _test_missing_values_transform(input_type: str, missing: str) -> None:
-    observations = [['a', 'b'], ['b', 'a'], ['b', 'b'],
-                    ['a', 'c'], ['c', 'a']]
-    test_observations = [['a', 'b'], ['b', 'a'], ['b', np.nan],
-                         ['a', 'c'], [np.nan, 'a']]
-    encoded = np.array([[1., 0., 0., 0., 1., 0.],
-                        [0., 1., 0., 1., 0., 0.],
-                        [0., 1., 0., 0., 0., 0.],
-                        [1., 0., 0., 0., 0., 1.],
-                        [0., 0., 0., 1., 0., 0.]])
+    observations = [["a", "b"], ["b", "a"], ["b", "b"], ["a", "c"], ["c", "a"]]
+    test_observations = [
+        ["a", "b"],
+        ["b", "a"],
+        ["b", np.nan],
+        ["a", "c"],
+        [np.nan, "a"],
+    ]
+    encoded = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        ]
+    )
 
-    if input_type == 'numpy':
+    if input_type == "numpy":
         test_observations = np.array(test_observations, dtype=object)
-    elif input_type == 'pandas':
+    elif input_type == "pandas":
         pd = pytest.importorskip("pandas")
         test_observations = pd.DataFrame(test_observations)
 
     sim_enc = similarity_encoder.SimilarityEncoder(handle_missing=missing)
-    if missing == 'error':
+    if missing == "error":
         sim_enc.fit_transform(observations)
         with pytest.raises(ValueError, match=r"Found missing values in input"):
             sim_enc.transform(test_observations)
-    elif missing == '':
+    elif missing == "":
         sim_enc.fit_transform(observations)
         ans = sim_enc.transform(test_observations)
         assert np.allclose(encoded, ans)
 
 
-def _test_similarity(similarity_f: Callable, hashing_dim: Optional[int] = None,
-                     categories: str = 'auto', n_prototypes: int = None,
-                     ) -> None:
+def _test_similarity(
+    similarity_f: Callable,
+    hashing_dim: Optional[int] = None,
+    categories: str = "auto",
+    n_prototypes: int = None,
+) -> None:
     if n_prototypes is None:
-        X = np.array(['aa', 'aaa', 'aaab']).reshape(-1, 1)
-        X_test = np.array([['Aa', 'aAa', 'aaa', 'aaab', ' aaa  c']]).reshape(-1, 1)
+        X = np.array(["aa", "aaa", "aaab"]).reshape(-1, 1)
+        X_test = np.array([["Aa", "aAa", "aaa", "aaab", " aaa  c"]]).reshape(-1, 1)
 
         model = similarity_encoder.SimilarityEncoder(
-            hashing_dim=hashing_dim, categories=categories,
-            n_prototypes=n_prototypes, ngram_range=(3, 3))
+            hashing_dim=hashing_dim,
+            categories=categories,
+            n_prototypes=n_prototypes,
+            ngram_range=(3, 3),
+        )
 
         encoder = model.fit(X).transform(X_test)
 
@@ -127,31 +145,36 @@ def _test_similarity(similarity_f: Callable, hashing_dim: Optional[int] = None,
         numpy.testing.assert_almost_equal(encoder, ans)
     else:
         X = np.array(
-            ['aac', 'aaa', 'aaab', 'aaa', 'aaab', 'aaa', 'aaab', 'aaa']
+            ["aac", "aaa", "aaab", "aaa", "aaab", "aaa", "aaab", "aaa"]
         ).reshape(-1, 1)
-        X_test = np.array([['Aa', 'aAa', 'aaa', 'aaab', ' aaa  c']]
-                          ).reshape(-1, 1)
+        X_test = np.array([["Aa", "aAa", "aaa", "aaab", " aaa  c"]]).reshape(-1, 1)
 
         try:
             model = similarity_encoder.SimilarityEncoder(
-                hashing_dim=hashing_dim, categories=categories,
-                n_prototypes=n_prototypes, random_state=42, ngram_range=(3, 3))
+                hashing_dim=hashing_dim,
+                categories=categories,
+                n_prototypes=n_prototypes,
+                random_state=42,
+                ngram_range=(3, 3),
+            )
         except ValueError as e:
-            assert (e.__str__() == 'n_prototypes expected None or a positive non null integer')
+            assert (
+                e.__str__()
+                == "n_prototypes expected None or a positive non null integer"
+            )
             return
 
         encoder = model.fit(X).transform(X_test)
         if n_prototypes == 1:
-            assert (model.categories_ == ['aaa'])
+            assert model.categories_ == ["aaa"]
         elif n_prototypes == 2:
-            a = [np.array(['aaa', 'aaab'], dtype='<U4')]
-            assert (np.array_equal(a, model.categories_))
+            a = [np.array(["aaa", "aaab"], dtype="<U4")]
+            assert np.array_equal(a, model.categories_)
         elif n_prototypes == 3:
-            a = [np.array(['aaa', 'aaab', 'aac'], dtype='<U4')]
-            assert (np.array_equal(a, model.categories_))
+            a = [np.array(["aaa", "aaab", "aac"], dtype="<U4")]
+            assert np.array_equal(a, model.categories_)
 
-        ans = np.zeros((len(X_test),
-                        len(np.array(model.categories_).reshape(-1))))
+        ans = np.zeros((len(X_test), len(np.array(model.categories_).reshape(-1))))
         for i, x_t in enumerate(X_test.reshape(-1)):
             for j, x in enumerate(np.array(model.categories_).reshape(-1)):
                 ans[i, j] = similarity_f(x_t, x, 3)
@@ -160,23 +183,35 @@ def _test_similarity(similarity_f: Callable, hashing_dim: Optional[int] = None,
 
 
 def test_similarity_encoder() -> None:
-    categories = ['auto', 'most_frequent', 'k-means']
+    categories = ["auto", "most_frequent", "k-means"]
     for category in categories:
-        if category == 'auto':
-            _test_similarity(string_distances.ngram_similarity,
-                             categories=category, n_prototypes=None)
-            _test_similarity(string_distances.ngram_similarity,
-                             hashing_dim=2 ** 16, categories=category)
+        if category == "auto":
+            _test_similarity(
+                string_distances.ngram_similarity,
+                categories=category,
+                n_prototypes=None,
+            )
+            _test_similarity(
+                string_distances.ngram_similarity,
+                hashing_dim=2**16,
+                categories=category,
+            )
         else:
             for i in range(1, 4):
-                _test_similarity(string_distances.ngram_similarity,
-                                 categories=category, n_prototypes=i)
-                _test_similarity(string_distances.ngram_similarity,
-                                 hashing_dim=2 ** 16, categories=category,
-                                 n_prototypes=i)
+                _test_similarity(
+                    string_distances.ngram_similarity,
+                    categories=category,
+                    n_prototypes=i,
+                )
+                _test_similarity(
+                    string_distances.ngram_similarity,
+                    hashing_dim=2**16,
+                    categories=category,
+                    n_prototypes=i,
+                )
 
-    input_types = ['list', 'numpy', 'pandas']
-    handle_missing = ['aaa', 'error', '']
+    input_types = ["list", "numpy", "pandas"]
+    handle_missing = ["aaa", "error", ""]
     for input_type in input_types:
         for missing in handle_missing:
             _test_missing_values(input_type, missing)
@@ -184,40 +219,126 @@ def test_similarity_encoder() -> None:
 
 
 def test_kmeans_protoypes() -> None:
-    X_test = np.array(['cbbba', 'baaac', 'accc'])
+    X_test = np.array(["cbbba", "baaac", "accc"])
     proto = get_kmeans_prototypes(X_test, 3)
     assert np.array_equal(np.sort(proto), np.sort(X_test))
 
 
 def test_reproducibility() -> None:
     sim_enc = similarity_encoder.SimilarityEncoder(
-        categories='k-means', n_prototypes=10, random_state=435,
+        categories="k-means",
+        n_prototypes=10,
+        random_state=435,
     )
-    X = np.array([' %s ' % chr(i) for i in range(32, 127)]).reshape((-1, 1))
+    X = np.array([" %s " % chr(i) for i in range(32, 127)]).reshape((-1, 1))
     prototypes = sim_enc.fit(X).categories_[0]
     for i in range(10):
-        assert (np.array_equal(prototypes, sim_enc.fit(X).categories_[0]))
+        assert np.array_equal(prototypes, sim_enc.fit(X).categories_[0])
 
 
 def test_get_features() -> None:
     # See https://github.com/dirty-cat/dirty_cat/issues/168
     sim_enc = similarity_encoder.SimilarityEncoder(random_state=435)
-    X = np.array(['%s' % chr(i) for i in range(32, 127)]).reshape((-1, 1))
+    X = np.array(["%s" % chr(i) for i in range(32, 127)]).reshape((-1, 1))
     sim_enc.fit(X)
-    if Version(sklearn_version) < Version('1.0'):
+    if Version(sklearn_version) < Version("1.0"):
         feature_names = sim_enc.get_feature_names()
     else:
         feature_names = sim_enc.get_feature_names_out()
     assert feature_names.tolist() == [
-        'x0_ ', 'x0_!', 'x0_"', 'x0_#', 'x0_$', 'x0_%', 'x0_&', "x0_'", 'x0_(',
-        'x0_)', 'x0_*', 'x0_+', 'x0_,', 'x0_-', 'x0_.', 'x0_/', 'x0_0', 'x0_1',
-        'x0_2', 'x0_3', 'x0_4', 'x0_5', 'x0_6', 'x0_7', 'x0_8', 'x0_9', 'x0_:',
-        'x0_;', 'x0_<', 'x0_=', 'x0_>', 'x0_?', 'x0_@', 'x0_A', 'x0_B', 'x0_C',
-        'x0_D', 'x0_E', 'x0_F', 'x0_G', 'x0_H', 'x0_I', 'x0_J', 'x0_K', 'x0_L',
-        'x0_M', 'x0_N', 'x0_O', 'x0_P', 'x0_Q', 'x0_R', 'x0_S', 'x0_T', 'x0_U',
-        'x0_V', 'x0_W', 'x0_X', 'x0_Y', 'x0_Z', 'x0_[', 'x0_\\', 'x0_]', 'x0_^',
-        'x0__', 'x0_`', 'x0_a', 'x0_b', 'x0_c', 'x0_d', 'x0_e', 'x0_f', 'x0_g',
-        'x0_h', 'x0_i', 'x0_j', 'x0_k', 'x0_l', 'x0_m', 'x0_n', 'x0_o', 'x0_p',
-        'x0_q', 'x0_r', 'x0_s', 'x0_t', 'x0_u', 'x0_v', 'x0_w', 'x0_x', 'x0_y',
-        'x0_z', 'x0_{', 'x0_|', 'x0_}', 'x0_~'
+        "x0_ ",
+        "x0_!",
+        'x0_"',
+        "x0_#",
+        "x0_$",
+        "x0_%",
+        "x0_&",
+        "x0_'",
+        "x0_(",
+        "x0_)",
+        "x0_*",
+        "x0_+",
+        "x0_,",
+        "x0_-",
+        "x0_.",
+        "x0_/",
+        "x0_0",
+        "x0_1",
+        "x0_2",
+        "x0_3",
+        "x0_4",
+        "x0_5",
+        "x0_6",
+        "x0_7",
+        "x0_8",
+        "x0_9",
+        "x0_:",
+        "x0_;",
+        "x0_<",
+        "x0_=",
+        "x0_>",
+        "x0_?",
+        "x0_@",
+        "x0_A",
+        "x0_B",
+        "x0_C",
+        "x0_D",
+        "x0_E",
+        "x0_F",
+        "x0_G",
+        "x0_H",
+        "x0_I",
+        "x0_J",
+        "x0_K",
+        "x0_L",
+        "x0_M",
+        "x0_N",
+        "x0_O",
+        "x0_P",
+        "x0_Q",
+        "x0_R",
+        "x0_S",
+        "x0_T",
+        "x0_U",
+        "x0_V",
+        "x0_W",
+        "x0_X",
+        "x0_Y",
+        "x0_Z",
+        "x0_[",
+        "x0_\\",
+        "x0_]",
+        "x0_^",
+        "x0__",
+        "x0_`",
+        "x0_a",
+        "x0_b",
+        "x0_c",
+        "x0_d",
+        "x0_e",
+        "x0_f",
+        "x0_g",
+        "x0_h",
+        "x0_i",
+        "x0_j",
+        "x0_k",
+        "x0_l",
+        "x0_m",
+        "x0_n",
+        "x0_o",
+        "x0_p",
+        "x0_q",
+        "x0_r",
+        "x0_s",
+        "x0_t",
+        "x0_u",
+        "x0_v",
+        "x0_w",
+        "x0_x",
+        "x0_y",
+        "x0_z",
+        "x0_{",
+        "x0_|",
+        "x0_}",
+        "x0_~",
     ]

--- a/dirty_cat/test/test_sklearn.py
+++ b/dirty_cat/test/test_sklearn.py
@@ -1,7 +1,12 @@
 from sklearn.utils.estimator_checks import check_estimator
 
-from dirty_cat import (DatetimeEncoder, GapEncoder, MinHashEncoder,
-                       SimilarityEncoder, SuperVectorizer, TargetEncoder)
+from dirty_cat import (
+    DatetimeEncoder,
+    GapEncoder,
+    MinHashEncoder,
+    SimilarityEncoder,
+    TargetEncoder,
+)
 
 
 def test_sklearn_compatible_DatetimeEncoder():
@@ -20,7 +25,7 @@ def test_sklearn_compatible_SimilarityEncoder():
     check_estimator(SimilarityEncoder())
 
 
-#def test_sklearn_compatible_SuperVectorizer():
+# def test_sklearn_compatible_SuperVectorizer():
 #    check_estimator(SuperVectorizer())
 
 

--- a/dirty_cat/test/test_string_distances.py
+++ b/dirty_cat/test/test_string_distances.py
@@ -1,16 +1,25 @@
+from typing import List, Tuple
+
 import numpy as np
 
-from typing import List, Tuple
 from dirty_cat import string_distances
 
 
 def test_get_unique_ngrams() -> None:
-    string = 'test'
+    string = "test"
     true_ngrams = {
-        (' ', 't'), ('t', 'e'), ('e', 's'), ('s', 't'),
-        ('t', ' '), (' ', 't', 'e'), ('t', 'e', 's'),
-        ('e', 's', 't'), ('s', 't', ' '), (' ', 't', 'e', 's'),
-        ('t', 'e', 's', 't'), ('e', 's', 't', ' ')
+        (" ", "t"),
+        ("t", "e"),
+        ("e", "s"),
+        ("s", "t"),
+        ("t", " "),
+        (" ", "t", "e"),
+        ("t", "e", "s"),
+        ("e", "s", "t"),
+        ("s", "t", " "),
+        (" ", "t", "e", "s"),
+        ("t", "e", "s", "t"),
+        ("e", "s", "t", " "),
     }
     ngram_range = (2, 4)
     ngrams = string_distances.get_unique_ngrams(string, ngram_range)
@@ -24,16 +33,15 @@ def _random_string_pairs(n_pairs=50, seed=1) -> List[Tuple[str, str]]:
     for n in range(n_pairs):
         s1_len = rng.randint(50)
         s2_len = rng.randint(50)
-        s1 = ''.join(rng.choice(characters, s1_len))
-        s2 = ''.join(rng.choice(characters, s2_len))
+        s1 = "".join(rng.choice(characters, s1_len))
+        s2 = "".join(rng.choice(characters, s2_len))
         pairs.append((s1, s2))
     return pairs
 
 
 def _check_symmetry(dist_func, *args, **kwargs) -> None:
-    for (a, b) in _random_string_pairs():
-        assert dist_func(
-            a, b, *args, **kwargs) == dist_func(b, a, *args, **kwargs)
+    for a, b in _random_string_pairs():
+        assert dist_func(a, b, *args, **kwargs) == dist_func(b, a, *args, **kwargs)
 
 
 def test_ngram_similarity() -> None:

--- a/dirty_cat/test/test_super_vectorizer.py
+++ b/dirty_cat/test/test_super_vectorizer.py
@@ -1,24 +1,20 @@
+from typing import Dict, List
+
 import numpy as np
+import pandas as pd
 import pytest
 import sklearn
-import pandas as pd
-
-from typing import List, Dict
-
+from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import check_is_fitted
-from sklearn.exceptions import NotFittedError
 
-from dirty_cat import SuperVectorizer
-from dirty_cat import GapEncoder
+from dirty_cat import GapEncoder, SuperVectorizer
 from dirty_cat.utils import Version
 
 
-def check_same_transformers(expected_transformers: dict,
-                            actual_transformers: list):
+def check_same_transformers(expected_transformers: dict, actual_transformers: list):
     # Construct the dict from the actual transformers
-    actual_transformers_dict = {name: cols
-                                for name, trans, cols in actual_transformers}
+    actual_transformers_dict = {name: cols for name, trans, cols in actual_transformers}
     assert actual_transformers_dict == expected_transformers
 
 
@@ -28,8 +24,9 @@ def type_equality(expected_type, actual_type):
     assuming object and str types are equivalent
     (considered as categorical by the SuperVectorizer).
     """
-    if (isinstance(expected_type, object) or isinstance(expected_type, str))\
-            and (isinstance(actual_type, object) or isinstance(actual_type, str)):
+    if (isinstance(expected_type, object) or isinstance(expected_type, str)) and (
+        isinstance(actual_type, object) or isinstance(actual_type, str)
+    ):
         return True
     else:
         return expected_type == actual_type
@@ -40,14 +37,22 @@ def _get_clean_dataframe() -> pd.DataFrame:
     Creates a simple DataFrame with various types of data,
     and without missing values.
     """
-    return pd.DataFrame({
-        'int': pd.Series([15, 56, 63, 12, 44], dtype='int'),
-        'float': pd.Series([5.2, 2.4, 6.2, 10.45, 9.], dtype='float'),
-        'str1': pd.Series(['public', 'private', 'private', 'private', 'public'], dtype='string'),
-        'str2': pd.Series(['officer', 'manager', 'lawyer', 'chef', 'teacher'], dtype='string'),
-        'cat1': pd.Series(['yes', 'yes', 'no', 'yes', 'no'], dtype='category'),
-        'cat2': pd.Series(['20K+', '40K+', '60K+', '30K+', '50K+'], dtype='category'),
-    })
+    return pd.DataFrame(
+        {
+            "int": pd.Series([15, 56, 63, 12, 44], dtype="int"),
+            "float": pd.Series([5.2, 2.4, 6.2, 10.45, 9.0], dtype="float"),
+            "str1": pd.Series(
+                ["public", "private", "private", "private", "public"], dtype="string"
+            ),
+            "str2": pd.Series(
+                ["officer", "manager", "lawyer", "chef", "teacher"], dtype="string"
+            ),
+            "cat1": pd.Series(["yes", "yes", "no", "yes", "no"], dtype="category"),
+            "cat2": pd.Series(
+                ["20K+", "40K+", "60K+", "30K+", "50K+"], dtype="category"
+            ),
+        }
+    )
 
 
 def _get_dirty_dataframe() -> pd.DataFrame:
@@ -56,23 +61,33 @@ def _get_dirty_dataframe() -> pd.DataFrame:
     We'll use different types of missing values (np.nan, pd.NA, None)
     to test the robustness of the vectorizer.
     """
-    return pd.DataFrame({
-        'int': pd.Series([15, 56, pd.NA, 12, 44], dtype='Int64'),
-        'float': pd.Series([5.2, 2.4, 6.2, 10.45, np.nan], dtype='Float64'),
-        'str1': pd.Series(['public', np.nan, 'private', 'private', 'public'], dtype='object'),
-        'str2': pd.Series(['officer', 'manager', None, 'chef', 'teacher'], dtype='object'),
-        'cat1': pd.Series([np.nan, 'yes', 'no', 'yes', 'no'], dtype='object'),
-        'cat2': pd.Series(['20K+', '40K+', '60K+', '30K+', np.nan], dtype='object'),
-    })
+    return pd.DataFrame(
+        {
+            "int": pd.Series([15, 56, pd.NA, 12, 44], dtype="Int64"),
+            "float": pd.Series([5.2, 2.4, 6.2, 10.45, np.nan], dtype="Float64"),
+            "str1": pd.Series(
+                ["public", np.nan, "private", "private", "public"], dtype="object"
+            ),
+            "str2": pd.Series(
+                ["officer", "manager", None, "chef", "teacher"], dtype="object"
+            ),
+            "cat1": pd.Series([np.nan, "yes", "no", "yes", "no"], dtype="object"),
+            "cat2": pd.Series(["20K+", "40K+", "60K+", "30K+", np.nan], dtype="object"),
+        }
+    )
 
 
 def _get_numpy_array() -> np.array:
-    return np.array([["15", "56", pd.NA, "12", ""],
+    return np.array(
+        [
+            ["15", "56", pd.NA, "12", ""],
             ["?", "2.4", "6.2", "10.45", np.nan],
-            ['public', np.nan, 'private', 'private', pd.NA],
-            ['officer', 'manager', None, 'chef', 'teacher'],
-            [np.nan, 'yes', 'no', 'yes', 'no'],
-            ['20K+', '40K+', '60K+', '30K+', np.nan]]).T
+            ["public", np.nan, "private", "private", pd.NA],
+            ["officer", "manager", None, "chef", "teacher"],
+            [np.nan, "yes", "no", "yes", "no"],
+            ["20K+", "40K+", "60K+", "30K+", np.nan],
+        ]
+    ).T
 
 
 def _get_list_of_lists() -> list:
@@ -84,49 +99,60 @@ def _get_datetimes_dataframe() -> pd.DataFrame:
     Creates a DataFrame with various date formats,
     already converted or to be converted.
     """
-    return pd.DataFrame({
-        "pd_datetime": [
-            pd.Timestamp("2019-01-01"),
-            pd.Timestamp("2019-01-02"),
-            pd.Timestamp("2019-01-03"),
-            pd.Timestamp("2019-01-04"),
-            pd.Timestamp("2019-01-05")],
-        "np_datetime": [np.datetime64('2018-01-01'),
-                        np.datetime64('2018-01-02'),
-                        np.datetime64('2018-01-03'),
-                        np.datetime64('2018-01-04'),
-                        np.datetime64('2018-01-05')],
-        "dmy-": ['11-12-2029',
-                 '02-12-2012',
-                 '11-09-2012',
-                 '13-02-2000',
-                 '10-11-2001'],
-        # "mdy-": ['11-13-2013',
-        #          '02-12-2012',
-        #          '11-31-2012',
-        #          '05-02-2000',
-        #          '10-11-2001'],
-        "ymd/": ['2014/12/31',
-                 '2001/11/23',
-                 '2005/02/12',
-                 '1997/11/01',
-                 '2011/05/05'],
-        "ymd/_hms:": ["2014/12/31 00:31:01",
-                      "2014/12/30 00:31:12",
-                      "2014/12/31 23:31:23",
-                      "2015/12/31 01:31:34",
-                      "2014/01/31 00:32:45"],
-    })
+    return pd.DataFrame(
+        {
+            "pd_datetime": [
+                pd.Timestamp("2019-01-01"),
+                pd.Timestamp("2019-01-02"),
+                pd.Timestamp("2019-01-03"),
+                pd.Timestamp("2019-01-04"),
+                pd.Timestamp("2019-01-05"),
+            ],
+            "np_datetime": [
+                np.datetime64("2018-01-01"),
+                np.datetime64("2018-01-02"),
+                np.datetime64("2018-01-03"),
+                np.datetime64("2018-01-04"),
+                np.datetime64("2018-01-05"),
+            ],
+            "dmy-": [
+                "11-12-2029",
+                "02-12-2012",
+                "11-09-2012",
+                "13-02-2000",
+                "10-11-2001",
+            ],
+            # "mdy-": ['11-13-2013',
+            #          '02-12-2012',
+            #          '11-31-2012',
+            #          '05-02-2000',
+            #          '10-11-2001'],
+            "ymd/": [
+                "2014/12/31",
+                "2001/11/23",
+                "2005/02/12",
+                "1997/11/01",
+                "2011/05/05",
+            ],
+            "ymd/_hms:": [
+                "2014/12/31 00:31:01",
+                "2014/12/30 00:31:12",
+                "2014/12/31 23:31:23",
+                "2015/12/31 01:31:34",
+                "2014/01/31 00:32:45",
+            ],
+        }
+    )
 
 
 def _test_possibilities(
-        X,
-        expected_transformers_df: Dict[str, List[str]],
-        expected_transformers_2: Dict[str, List[str]],
-        expected_transformers_np_no_cast: Dict[str, List[int]],
-        expected_transformers_series: Dict[str, List[str]],
-        expected_transformers_plain: Dict[str, List[str]],
-        expected_transformers_np_cast: Dict[str, List[int]],
+    X,
+    expected_transformers_df: Dict[str, List[str]],
+    expected_transformers_2: Dict[str, List[str]],
+    expected_transformers_np_no_cast: Dict[str, List[int]],
+    expected_transformers_series: Dict[str, List[str]],
+    expected_transformers_plain: Dict[str, List[str]],
+    expected_transformers_np_cast: Dict[str, List[int]],
 ):
     """
     Do a bunch of tests with the SuperVectorizer.
@@ -142,26 +168,24 @@ def _test_possibilities(
     )
     # Warning: order-dependant
     vectorizer_base.fit_transform(X)
-    check_same_transformers(expected_transformers_df,
-                            vectorizer_base.transformers)
+    check_same_transformers(expected_transformers_df, vectorizer_base.transformers)
 
     # Test with higher cardinality threshold and no numeric transformer
     vectorizer_default = SuperVectorizer()  # Using default values
     vectorizer_default.fit_transform(X)
-    check_same_transformers(expected_transformers_2,
-                            vectorizer_default.transformers)
+    check_same_transformers(expected_transformers_2, vectorizer_default.transformers)
 
     # Test with a numpy array
     arr = X.to_numpy()
     # Instead of the columns names, we'll have the column indices.
     vectorizer_base.fit_transform(arr)
-    check_same_transformers(expected_transformers_np_no_cast,
-                            vectorizer_base.transformers)
+    check_same_transformers(
+        expected_transformers_np_no_cast, vectorizer_base.transformers
+    )
 
     # Test with pandas series
-    vectorizer_base.fit_transform(X['cat1'])
-    check_same_transformers(expected_transformers_series,
-                            vectorizer_base.transformers)
+    vectorizer_base.fit_transform(X["cat1"])
+    check_same_transformers(expected_transformers_series, vectorizer_base.transformers)
 
     # Test casting values
     vectorizer_cast = SuperVectorizer(
@@ -170,15 +194,13 @@ def _test_possibilities(
         high_card_cat_transformer=GapEncoder(n_components=2),
         numerical_transformer=StandardScaler(),
     )
-    X_str = X.astype('object')
+    X_str = X.astype("object")
     # With pandas
     vectorizer_cast.fit_transform(X_str)
-    check_same_transformers(expected_transformers_plain,
-                            vectorizer_cast.transformers)
+    check_same_transformers(expected_transformers_plain, vectorizer_cast.transformers)
     # With numpy
     vectorizer_cast.fit_transform(X_str.to_numpy())
-    check_same_transformers(expected_transformers_np_cast,
-                            vectorizer_cast.transformers)
+    check_same_transformers(expected_transformers_np_cast, vectorizer_cast.transformers)
 
 
 def test_with_clean_data():
@@ -189,30 +211,30 @@ def test_with_clean_data():
     X = _get_clean_dataframe()
     # Define the transformers we'll use throughout the test.
     expected_transformers_df = {
-        'numeric': ['int', 'float'],
-        'low_card_cat': ['str1', 'cat1'],
-        'high_card_cat': ['str2', 'cat2'],
+        "numeric": ["int", "float"],
+        "low_card_cat": ["str1", "cat1"],
+        "high_card_cat": ["str2", "cat2"],
     }
     expected_transformers_2 = {
-        'low_card_cat': ['str1', 'str2', 'cat1', 'cat2'],
+        "low_card_cat": ["str1", "str2", "cat1", "cat2"],
     }
     expected_transformers_np_no_cast = {
-        'low_card_cat': [2, 4],
-        'high_card_cat': [3, 5],
-        'numeric': [0, 1]
+        "low_card_cat": [2, 4],
+        "high_card_cat": [3, 5],
+        "numeric": [0, 1],
     }
     expected_transformers_series = {
-        'low_card_cat': ['cat1'],
+        "low_card_cat": ["cat1"],
     }
     expected_transformers_plain = {
-        'high_card_cat': ['str2', 'cat2'],
-        'low_card_cat': ['str1', 'cat1'],
-        'numeric': ['int', 'float']
+        "high_card_cat": ["str2", "cat2"],
+        "low_card_cat": ["str1", "cat1"],
+        "numeric": ["int", "float"],
     }
     expected_transformers_np_cast = {
-        'numeric': [0, 1],
-        'low_card_cat': [2, 4],
-        'high_card_cat': [3, 5],
+        "numeric": [0, 1],
+        "low_card_cat": [2, 4],
+        "high_card_cat": [3, 5],
     }
     _test_possibilities(
         X,
@@ -233,30 +255,30 @@ def test_with_dirty_data() -> None:
     X = _get_dirty_dataframe()
     # Define the transformers we'll use throughout the test.
     expected_transformers_df = {
-        'numeric': ['int', 'float'],
-        'low_card_cat': ['str1', 'cat1'],
-        'high_card_cat': ['str2', 'cat2'],
+        "numeric": ["int", "float"],
+        "low_card_cat": ["str1", "cat1"],
+        "high_card_cat": ["str2", "cat2"],
     }
     expected_transformers_2 = {
-        'low_card_cat': ['str1', 'str2', 'cat1', 'cat2'],
+        "low_card_cat": ["str1", "str2", "cat1", "cat2"],
     }
     expected_transformers_np_no_cast = {
-        'low_card_cat': [2, 4],
-        'high_card_cat': [3, 5],
-        'numeric': [0, 1],
+        "low_card_cat": [2, 4],
+        "high_card_cat": [3, 5],
+        "numeric": [0, 1],
     }
     expected_transformers_series = {
-        'low_card_cat': ['cat1'],
+        "low_card_cat": ["cat1"],
     }
     expected_transformers_plain = {
-        'high_card_cat': ['str2', 'cat2'],
-        'low_card_cat': ['str1', 'cat1'],
-        'numeric': ['int', 'float']
+        "high_card_cat": ["str2", "cat2"],
+        "low_card_cat": ["str1", "cat1"],
+        "numeric": ["int", "float"],
     }
     expected_transformers_np_cast = {
-        'numeric': [0, 1],
-        'low_card_cat': [2, 4],
-        'high_card_cat': [3, 5],
+        "numeric": [0, 1],
+        "low_card_cat": [2, 4],
+        "high_card_cat": [3, 5],
     }
 
     _test_possibilities(
@@ -298,14 +320,13 @@ def test_auto_cast() -> None:
         "str1": "object",
         "str2": "object",
         "cat1": "object",
-        "cat2": "object"
+        "cat2": "object",
     }
 
     X = _get_clean_dataframe()
     X_trans = vectorizer._auto_cast(X)
     for col in X_trans.columns:
-        assert type_equality(expected_types_clean_dataframe[col],
-                             X_trans[col].dtype)
+        assert type_equality(expected_types_clean_dataframe[col], X_trans[col].dtype)
 
     # Test that missing values don't prevent type detection
     expected_types_dirty_dataframe = {
@@ -314,14 +335,13 @@ def test_auto_cast() -> None:
         "str1": "object",
         "str2": "object",
         "cat1": "object",
-        "cat2": "object"
+        "cat2": "object",
     }
 
     X = _get_dirty_dataframe()
     X_trans = vectorizer._auto_cast(X)
     for col in X_trans.columns:
-        assert type_equality(expected_types_dirty_dataframe[col],
-                             X_trans[col].dtype)
+        assert type_equality(expected_types_dirty_dataframe[col], X_trans[col].dtype)
 
 
 def test_with_arrays():
@@ -330,11 +350,11 @@ def test_with_arrays():
     a list of lists or a numpy array.
     """
     expected_transformers = {
-        'numeric': [0, 1],
-        'low_card_cat': [2, 4],
-        'high_card_cat': [3, 5],
+        "numeric": [0, 1],
+        "low_card_cat": [2, 4],
+        "high_card_cat": [3, 5],
     }
-    vectorizer =  SuperVectorizer(
+    vectorizer = SuperVectorizer(
         cardinality_threshold=4,
         # we must have n_samples = 5 >= n_components
         high_card_cat_transformer=GapEncoder(n_components=2),
@@ -353,10 +373,10 @@ def test_with_arrays():
 def test_get_feature_names_out() -> None:
     X = _get_clean_dataframe()
 
-    vec_w_pass = SuperVectorizer(remainder='passthrough')
+    vec_w_pass = SuperVectorizer(remainder="passthrough")
     vec_w_pass.fit(X)
 
-    if Version(sklearn.__version__) < Version('0.23'):
+    if Version(sklearn.__version__) < Version("0.23"):
         with pytest.raises(NotImplementedError):
             # Prior to sklearn 0.23, ColumnTransformer.get_feature_names
             # with "passthrough" transformer(s) raises a NotImplementedError
@@ -364,26 +384,49 @@ def test_get_feature_names_out() -> None:
     else:
         # In this test, order matters. If it doesn't, convert to set.
         expected_feature_names_pass = [
-            'str1_private', 'str1_public',
-            'str2_chef', 'str2_lawyer', 'str2_manager', 'str2_officer', 'str2_teacher',
-            'cat1_no', 'cat1_yes', 'cat2_20K+', 'cat2_30K+', 'cat2_40K+', 'cat2_50K+', 'cat2_60K+',
-            'int', 'float'
+            "str1_private",
+            "str1_public",
+            "str2_chef",
+            "str2_lawyer",
+            "str2_manager",
+            "str2_officer",
+            "str2_teacher",
+            "cat1_no",
+            "cat1_yes",
+            "cat2_20K+",
+            "cat2_30K+",
+            "cat2_40K+",
+            "cat2_50K+",
+            "cat2_60K+",
+            "int",
+            "float",
         ]
-        if Version(sklearn.__version__) < Version('1.0'):
+        if Version(sklearn.__version__) < Version("1.0"):
             assert vec_w_pass.get_feature_names() == expected_feature_names_pass
         else:
             assert vec_w_pass.get_feature_names_out() == expected_feature_names_pass
 
-    vec_w_drop = SuperVectorizer(remainder='drop')
+    vec_w_drop = SuperVectorizer(remainder="drop")
     vec_w_drop.fit(X)
 
     # In this test, order matters. If it doesn't, convert to set.
     expected_feature_names_drop = [
-        'str1_private', 'str1_public',
-        'str2_chef', 'str2_lawyer', 'str2_manager', 'str2_officer', 'str2_teacher',
-        'cat1_no', 'cat1_yes', 'cat2_20K+', 'cat2_30K+', 'cat2_40K+', 'cat2_50K+', 'cat2_60K+'
+        "str1_private",
+        "str1_public",
+        "str2_chef",
+        "str2_lawyer",
+        "str2_manager",
+        "str2_officer",
+        "str2_teacher",
+        "cat1_no",
+        "cat1_yes",
+        "cat2_20K+",
+        "cat2_30K+",
+        "cat2_40K+",
+        "cat2_50K+",
+        "cat2_60K+",
     ]
-    if Version(sklearn.__version__) < Version('1.0'):
+    if Version(sklearn.__version__) < Version("1.0"):
         assert vec_w_drop.get_feature_names() == expected_feature_names_drop
     else:
         assert vec_w_drop.get_feature_names_out() == expected_feature_names_drop
@@ -402,12 +445,10 @@ def test_transform() -> None:
     X = _get_clean_dataframe()
     sup_vec = SuperVectorizer()
     sup_vec.fit(X)
-    s = [34, 5.5, 'private', 'manager', 'yes', '60K+']
+    s = [34, 5.5, "private", "manager", "yes", "60K+"]
     x = np.array(s).reshape(1, -1)
     x_trans = sup_vec.transform(x)
-    assert (
-            x_trans == [[1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 34, 5.5]]
-    ).all()
+    assert (x_trans == [[1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 34, 5.5]]).all()
 
 
 def test_fit_transform_equiv() -> None:
@@ -434,27 +475,27 @@ def test_fit_transform_equiv() -> None:
     assert np.allclose(enc1_x2, enc2_x2, rtol=0, atol=0, equal_nan=True)
 
 
-if __name__ == '__main__':
-    print('start test_super_vectorizer with clean df')
+if __name__ == "__main__":
+    print("start test_super_vectorizer with clean df")
     test_with_clean_data()
-    print('passed')
-    print('start test_super_vectorizer with dirty df')
+    print("passed")
+    print("start test_super_vectorizer with dirty df")
     test_with_dirty_data()
-    print('passed')
-    print('start test_auto_cast')
+    print("passed")
+    print("start test_auto_cast")
     test_auto_cast()
-    print('passed')
+    print("passed")
     print("start test_with_arrays")
     test_with_arrays()
     print("passed")
-    print('start  test_get_feature_names_out')
+    print("start  test_get_feature_names_out")
     test_get_feature_names_out()
-    print('passed')
-    print('start test_fit')
+    print("passed")
+    print("start test_fit")
     test_fit()
-    print('passed')
-    print('start fit_transform_equiv')
+    print("passed")
+    print("start fit_transform_equiv")
     test_fit_transform_equiv()
-    print('passed')
+    print("passed")
 
-    print('Done')
+    print("Done")

--- a/dirty_cat/test/test_target_encoder.py
+++ b/dirty_cat/test/test_target_encoder.py
@@ -6,80 +6,56 @@ from dirty_cat import target_encoder
 
 def test_target_encoder():
     lambda_ = target_encoder.lambda_
-    X1 = np.array(['Red',
-                   'red',
-                   'green',
-                   'blue',
-                   'green',
-                   'green',
-                   'blue',
-                   'red']).reshape(-1, 1)
-    X2 = np.array(['male',
-                   'male',
-                   'female',
-                   'male',
-                   'female',
-                   'female',
-                   'female',
-                   'male']).reshape(-1, 1)
+    X1 = np.array(
+        ["Red", "red", "green", "blue", "green", "green", "blue", "red"]
+    ).reshape(-1, 1)
+    X2 = np.array(
+        ["male", "male", "female", "male", "female", "female", "female", "male"]
+    ).reshape(-1, 1)
     X = np.hstack([X1, X2])
 
     # Case 1: binary-classification and regression
     y = np.array([1, 0, 0, 1, 0, 1, 0, 0])
     n = len(y)
 
-    Ey_ = 3/8
-    Eyx_ = {'color': {'Red': 1,
-                      'red': 0,
-                      'green': 1/3,
-                      'blue': .5},
-            'gender': {'male': .5,
-                       'female': .25}}
-    count_ = {'color': {'Red': 1,
-                        'red': 2,
-                        'green': 3,
-                        'blue': 2},
-              'gender': {'male': 4,
-                         'female': 4}}
+    Ey_ = 3 / 8
+    Eyx_ = {
+        "color": {"Red": 1, "red": 0, "green": 1 / 3, "blue": 0.5},
+        "gender": {"male": 0.5, "female": 0.25},
+    }
+    count_ = {
+        "color": {"Red": 1, "red": 2, "green": 3, "blue": 2},
+        "gender": {"male": 4, "female": 4},
+    }
 
     encoder = target_encoder.TargetEncoder()
     encoder.fit(X, y)
     for j in range(X.shape[1]):
         assert np.array_equal(encoder.categories_[j], np.unique(X[:, j]))
     assert Ey_ == encoder.Ey_
-    assert encoder.Eyx_[0] == Eyx_['color']
-    assert encoder.Eyx_[1] == Eyx_['gender']
+    assert encoder.Eyx_[0] == Eyx_["color"]
+    assert encoder.Eyx_[1] == Eyx_["gender"]
 
-    Xtest1 = np.array(['Red',
-                       'red',
-                       'blue',
-                       'green',
-                       'Red',
-                       'red',
-                       'blue',
-                       'green']).reshape(-1, 1)
-    Xtest2 = np.array(['male',
-                       'male',
-                       'male',
-                       'male',
-                       'female',
-                       'female',
-                       'female',
-                       'female']).reshape(-1, 1)
+    Xtest1 = np.array(
+        ["Red", "red", "blue", "green", "Red", "red", "blue", "green"]
+    ).reshape(-1, 1)
+    Xtest2 = np.array(
+        ["male", "male", "male", "male", "female", "female", "female", "female"]
+    ).reshape(-1, 1)
     Xtest = np.hstack([Xtest1, Xtest2])
 
     Xout = encoder.transform(Xtest)
 
-    ans_dict = {var:
-                {cat:
-                 Eyx_[var][cat] *
-                 lambda_(count_[var][cat], n/len(count_[var])) +
-                 Ey_ * (1 - lambda_(count_[var][cat], n/len(count_[var])))
-                 for cat in Eyx_[var]}
-                for var in Eyx_
-                }
+    ans_dict = {
+        var: {
+            cat: Eyx_[var][cat] * lambda_(count_[var][cat], n / len(count_[var]))
+            + Ey_ * (1 - lambda_(count_[var][cat], n / len(count_[var])))
+            for cat in Eyx_[var]
+        }
+        for var in Eyx_
+    }
     ans = np.zeros((n, 2))
-    for j, col in enumerate(['color', 'gender']):
+    for j, col in enumerate(["color", "gender"]):
         for i in range(n):
             ans[i, j] = ans_dict[col][Xtest[i, j]]
     assert np.array_equal(Xout, ans)
@@ -88,167 +64,129 @@ def test_target_encoder():
     y = np.array([1, 0, 2, 1, 0, 1, 0, 0])
     n = len(y)
 
-    encoder = target_encoder.TargetEncoder(clf_type='multiclass-clf')
+    encoder = target_encoder.TargetEncoder(clf_type="multiclass-clf")
     encoder.fit(X, y)
 
-    Ey_ = {0: 4/8, 1: 3/8, 2: 1/8}
+    Ey_ = {0: 4 / 8, 1: 3 / 8, 2: 1 / 8}
     Eyx_ = {
         0: {
-            'color': {'Red': 0,
-                      'red': 1,
-                      'green': 1 / 3,
-                      'blue': .5},
-            'gender': {'male': .5,
-                       'female': .5},
+            "color": {"Red": 0, "red": 1, "green": 1 / 3, "blue": 0.5},
+            "gender": {"male": 0.5, "female": 0.5},
         },
         1: {
-            'color': {'Red': 1,
-                      'red': 0,
-                      'green': 1 / 3,
-                      'blue': .5},
-            'gender': {'male': .5,
-                       'female': .25},
+            "color": {"Red": 1, "red": 0, "green": 1 / 3, "blue": 0.5},
+            "gender": {"male": 0.5, "female": 0.25},
         },
         2: {
-            'color': {'Red': 0,
-                      'red': 0,
-                      'green': 1 / 3,
-                      'blue': 0},
-            'gender': {'male': 0,
-                       'female': .25},
+            "color": {"Red": 0, "red": 0, "green": 1 / 3, "blue": 0},
+            "gender": {"male": 0, "female": 0.25},
         },
     }
     assert np.array_equal(np.unique(y), encoder.classes_)
     for k in [0, 1, 2]:
         assert Ey_[k] == encoder.Ey_[k]
-        assert encoder.Eyx_[k][0] == Eyx_[k]['color']
-        assert encoder.Eyx_[k][1] == Eyx_[k]['gender']
+        assert encoder.Eyx_[k][0] == Eyx_[k]["color"]
+        assert encoder.Eyx_[k][1] == Eyx_[k]["gender"]
 
-    count_ = {'color': {'Red': 1,
-                        'red': 2,
-                        'green': 3,
-                        'blue': 2},
-              'gender': {'male': 4,
-                         'female': 4}}
-    assert count_['color'] == encoder.counter_[0]
-    assert count_['gender'] == encoder.counter_[1]
+    count_ = {
+        "color": {"Red": 1, "red": 2, "green": 3, "blue": 2},
+        "gender": {"male": 4, "female": 4},
+    }
+    assert count_["color"] == encoder.counter_[0]
+    assert count_["gender"] == encoder.counter_[1]
 
     ans_dict = {0: {}, 1: {}, 2: {}}
     for k in [0, 1, 2]:
         ans_dict[k] = {
             var: {
-                cat: Eyx_[k][var][cat] * lambda_(count_[var][cat], n/len(count_[var])) + Ey_[k] * (1 - lambda_(count_[var][cat], n/len(count_[var])))
-                for cat in Eyx_[k][var]}
+                cat: Eyx_[k][var][cat] * lambda_(count_[var][cat], n / len(count_[var]))
+                + Ey_[k] * (1 - lambda_(count_[var][cat], n / len(count_[var])))
+                for cat in Eyx_[k][var]
+            }
             for var in Eyx_[k]
         }
 
-    ans = np.zeros((n, 2*3))
-    Xtest1 = np.array(['Red',
-                       'red',
-                       'blue',
-                       'green',
-                       'Red',
-                       'red',
-                       'blue',
-                       'green']).reshape(-1, 1)
-    Xtest2 = np.array(['male',
-                       'male',
-                       'male',
-                       'male',
-                       'female',
-                       'female',
-                       'female',
-                       'female']).reshape(-1, 1)
+    ans = np.zeros((n, 2 * 3))
+    Xtest1 = np.array(
+        ["Red", "red", "blue", "green", "Red", "red", "blue", "green"]
+    ).reshape(-1, 1)
+    Xtest2 = np.array(
+        ["male", "male", "male", "male", "female", "female", "female", "female"]
+    ).reshape(-1, 1)
     Xtest = np.hstack([Xtest1, Xtest2])
     for k in [0, 1, 2]:
-        for j, col in enumerate(['color', 'gender']):
+        for j, col in enumerate(["color", "gender"]):
             for i in range(n):
-                ans[i, 2*j+k] = ans_dict[k][col][Xtest[i, j]]
+                ans[i, 2 * j + k] = ans_dict[k][col][Xtest[i, j]]
 
     Xout = encoder.transform(Xtest)
-    ans = np.zeros((n, 2*3))
-    Xtest1 = np.array(['Red',
-                       'red',
-                       'blue',
-                       'green',
-                       'Red',
-                       'red',
-                       'blue',
-                       'green']).reshape(-1, 1)
-    Xtest2 = np.array(['male',
-                       'male',
-                       'male',
-                       'male',
-                       'female',
-                       'female',
-                       'female',
-                       'female']).reshape(-1, 1)
+    ans = np.zeros((n, 2 * 3))
+    Xtest1 = np.array(
+        ["Red", "red", "blue", "green", "Red", "red", "blue", "green"]
+    ).reshape(-1, 1)
+    Xtest2 = np.array(
+        ["male", "male", "male", "male", "female", "female", "female", "female"]
+    ).reshape(-1, 1)
     Xtest = np.hstack([Xtest1, Xtest2])
     for k in [0, 1, 2]:
-        for j, col in enumerate(['color', 'gender']):
+        for j, col in enumerate(["color", "gender"]):
             for i in range(n):
-                ans[i, j*3+k] = ans_dict[k][col][Xtest[i, j]]
-    encoder = target_encoder.TargetEncoder(clf_type='multiclass-clf')
+                ans[i, j * 3 + k] = ans_dict[k][col][Xtest[i, j]]
+    encoder = target_encoder.TargetEncoder(clf_type="multiclass-clf")
     encoder.fit(X, y)
     Xout = encoder.transform(Xtest)
     assert np.array_equal(Xout, ans)
 
 
 def _test_missing_values(input_type, missing):
-    lambda_ = target_encoder.lambda_
-    X = [['Red', 'male'],
-         [np.nan, 'male'],
-         ['green', 'female'],
-         ['blue', 'male'],
-         ['green', 'female'],
-         ['green', 'female'],
-         ['blue', 'female'],
-         [np.nan, np.nan]]
+    X = [
+        ["Red", "male"],
+        [np.nan, "male"],
+        ["green", "female"],
+        ["blue", "male"],
+        ["green", "female"],
+        ["green", "female"],
+        ["blue", "female"],
+        [np.nan, np.nan],
+    ]
 
-    color_cat = ['Red', '', 'green', 'blue']
-    gender_cat = ['male', '', 'female']
+    color_cat = ["Red", "", "green", "blue"]
+    gender_cat = ["male", "", "female"]
 
-    if input_type == 'numpy':
+    if input_type == "numpy":
         X = np.array(X, dtype=object)
-    elif input_type == 'pandas':
+    elif input_type == "pandas":
         pd = pytest.importorskip("pandas")
         X = pd.DataFrame(X)
 
     # Case 1: binary-classification and regression
     y = np.array([1, 0, 0, 1, 0, 1, 0, 0])
-    n = len(y)
 
-    Ey_ = 3/8
-    Eyx_ = {'color': {'Red': 1,
-                      '': 0,
-                      'green': 1/3,
-                      'blue': .5},
-            'gender': {'male': 2/3,
-                       'female': .25,
-                       '': 0}}
-    count_ = {'color': {'Red': 1,
-                        '': 2,
-                        'green': 3,
-                        'blue': 2},
-              'gender': {'male': 3,
-                         'female': 4,
-                         '': 1}}
+    Ey_ = 3 / 8
+    Eyx_ = {
+        "color": {"Red": 1, "": 0, "green": 1 / 3, "blue": 0.5},
+        "gender": {"male": 2 / 3, "female": 0.25, "": 0},
+    }
+    count_ = {
+        "color": {"Red": 1, "": 2, "green": 3, "blue": 2},
+        "gender": {"male": 3, "female": 4, "": 1},
+    }
 
     encoder = target_encoder.TargetEncoder(handle_missing=missing)
-    if missing == 'error':
+    if missing == "error":
         with pytest.raises(ValueError, match=r"Found missing values in input"):
             encoder.fit_transform(X, y)
         return
-    elif missing == '':
+    elif missing == "":
         encoder.fit_transform(X, y)
 
         assert set(encoder.categories_[0]) == set(color_cat)
         assert set(encoder.categories_[1]) == set(gender_cat)
         assert Ey_ == encoder.Ey_
-        assert encoder.Eyx_[0] == Eyx_['color']
-        assert encoder.Eyx_[1] == Eyx_['gender']
-        assert dict(encoder.counter_[0]) == count_['color']
-        assert dict(encoder.counter_[1]) == count_['gender']
+        assert encoder.Eyx_[0] == Eyx_["color"]
+        assert encoder.Eyx_[1] == Eyx_["gender"]
+        assert dict(encoder.counter_[0]) == count_["color"]
+        assert dict(encoder.counter_[1]) == count_["gender"]
     else:
         with pytest.raises(ValueError, match=r"expected any of"):
             encoder.fit_transform(X, y)
@@ -256,60 +194,48 @@ def _test_missing_values(input_type, missing):
 
 
 def _test_missing_values_transform(input_type, missing):
-    lambda_ = target_encoder.lambda_
-    X = [['Red', 'male'],
-         ['red', 'male'],
-         ['green', 'female'],
-         ['blue', 'male'],
-         ['green', 'female'],
-         ['green', 'female'],
-         ['blue', 'female'],
-         ['red', 'male']]
+    X = [
+        ["Red", "male"],
+        ["red", "male"],
+        ["green", "female"],
+        ["blue", "male"],
+        ["green", "female"],
+        ["green", "female"],
+        ["blue", "female"],
+        ["red", "male"],
+    ]
 
-    color_cat = ['Red', 'red', 'green', 'blue']
-    gender_cat = ['male', 'female']
+    X_test = [
+        ["Red", "male"],
+        [np.nan, "male"],
+        ["green", "female"],
+        ["blue", "male"],
+        ["green", "female"],
+        ["green", "female"],
+        ["blue", "female"],
+        [np.nan, np.nan],
+    ]
 
-    X_test = [['Red', 'male'],
-              [np.nan, 'male'],
-              ['green', 'female'],
-              ['blue', 'male'],
-              ['green', 'female'],
-              ['green', 'female'],
-              ['blue', 'female'],
-              [np.nan, np.nan]]
-
-    if input_type == 'numpy':
+    if input_type == "numpy":
         X_test = np.array(X_test, dtype=object)
-    elif input_type == 'pandas':
+    elif input_type == "pandas":
         pd = pytest.importorskip("pandas")
         X_test = pd.DataFrame(X_test)
 
     # Case 1: binary-classification and regression
     y = np.array([1, 0, 0, 1, 0, 1, 0, 0])
-    n = len(y)
 
-    Ey_ = 3/8
-    Eyx_ = {'color': {'Red': 1,
-                      'red': 0,
-                      'green': 1/3,
-                      'blue': .5},
-            'gender': {'male': .5,
-                       'female': .25}}
-    count_ = {'color': {'Red': 1,
-                        'red': 2,
-                        'green': 3,
-                        'blue': 2},
-              'gender': {'male': 4,
-                         'female': 4}}
+    Ey_ = 3 / 8
 
-    encoder = target_encoder.TargetEncoder(handle_unknown='ignore',
-                                           handle_missing=missing)
-    if missing == 'error':
+    encoder = target_encoder.TargetEncoder(
+        handle_unknown="ignore", handle_missing=missing
+    )
+    if missing == "error":
         encoder.fit_transform(X, y)
         with pytest.raises(ValueError, match=r"Found missing values in input"):
             encoder.transform(X_test)
         return
-    elif missing == '':
+    elif missing == "":
         encoder.fit_transform(X, y)
         ans = encoder.transform(X_test)
 
@@ -318,8 +244,8 @@ def _test_missing_values_transform(input_type, missing):
 
 
 def test_missing_values():
-    input_types = ['list', 'numpy', 'pandas']
-    handle_missing = ['aaa', 'error', '']
+    input_types = ["list", "numpy", "pandas"]
+    handle_missing = ["aaa", "error", ""]
     for input_type in input_types:
         for missing in handle_missing:
             _test_missing_values(input_type, missing)

--- a/dirty_cat/test/test_utils.py
+++ b/dirty_cat/test/test_utils.py
@@ -7,36 +7,36 @@ def test_lrudict():
     dict_ = LRUDict(10)
 
     for x in range(15):
-        dict_[x] = f'filled {x}'
+        dict_[x] = f"filled {x}"
 
     for x in range(5, 15):
         assert x in dict_
-        assert dict_[x] == f'filled {x}'
+        assert dict_[x] == f"filled {x}"
 
     for x in range(5):
-        assert (x not in dict_)
+        assert x not in dict_
 
 
 def test_version():
     # Test those specified in its docstring
-    assert Version('1.5') <= Version('1.6.5')
-    assert Version('1.5') <= '1.6.5'
+    assert Version("1.5") <= Version("1.6.5")
+    assert Version("1.5") <= "1.6.5"
 
-    assert (Version('1-5', separator='-') == Version('1-6-5', separator='-')) is False
-    assert (Version('1-5', separator='-') == '1-6-5') is False
+    assert (Version("1-5", separator="-") == Version("1-6-5", separator="-")) is False
+    assert (Version("1-5", separator="-") == "1-6-5") is False
     with pytest.raises(ValueError):
-        assert not (Version('1-5', separator='-') == '1.6.5')
+        assert not (Version("1-5", separator="-") == "1.6.5")
 
     # Test all comparison methods
-    assert Version('1.0') == Version('1.0')
-    assert (Version('1.0') != Version('1.0')) is False
+    assert Version("1.0") == Version("1.0")
+    assert (Version("1.0") != Version("1.0")) is False
 
-    assert Version('1.0') < Version('1.1')
-    assert Version('1.1') <= Version('1.5')
-    assert Version('1.1') <= Version('1.1')
-    assert (Version('1.1') < Version('1.1')) is False
+    assert Version("1.0") < Version("1.1")
+    assert Version("1.1") <= Version("1.5")
+    assert Version("1.1") <= Version("1.1")
+    assert (Version("1.1") < Version("1.1")) is False
 
-    assert Version('1.1') > Version('0.5')
-    assert Version('1.1') >= Version('0.9')
-    assert Version('1.1') >= Version('1.1')
-    assert (Version('1.1') >= Version('1.9')) is False
+    assert Version("1.1") > Version("0.5")
+    assert Version("1.1") >= Version("0.9")
+    assert Version("1.1") >= Version("1.1")
+    assert (Version("1.1") >= Version("1.9")) is False

--- a/dirty_cat/utils.py
+++ b/dirty_cat/utils.py
@@ -1,14 +1,15 @@
 import collections
-import numpy as np
+from typing import Any, Hashable, Tuple, Union
 
+import numpy as np
 from sklearn.utils import check_array
-from typing import Tuple, Union, Any, Hashable
 
 
 class LRUDict:
-    """ dict with limited capacity
+    """dict with limited capacity
 
     Using LRU eviction avoids memorizing a full dataset"""
+
     def __init__(self, capacity: int):
         self.capacity = capacity
         self.cache = collections.OrderedDict()
@@ -48,7 +49,7 @@ def check_input(X) -> np.array:
         force_all_finite=False,
     )
     # If the array contains both NaNs and strings, convert to object type
-    if X_.dtype.kind in {'U', 'S'}:  # contains strings
+    if X_.dtype.kind in {"U", "S"}:  # contains strings
         if np.any(X_ == "nan"):  # missing value converted to string
             return check_array(
                 np.array(X, dtype=object),
@@ -87,18 +88,20 @@ class Version:
     >>> Version('1-5', separator='-') == '1.6.5'  # Won't work!
     """
 
-    def __init__(self, value: str, separator: str = '.'):
+    def __init__(self, value: str, separator: str = "."):
         self.separator = separator
         self.major, self.minor = self._parse_version(value)
 
     def __repr__(self):
-        return f'Version({self.major}.{self.minor})'
+        return f"Version({self.major}.{self.minor})"
 
     def _parse_version(self, value: str) -> Tuple[int, int]:
         raw_parts = value.split(self.separator)
         if len(raw_parts) == 0:
-            raise ValueError(f'Could not extract version from {value!r} '
-                             f'(separator: {self.separator!r})')
+            raise ValueError(
+                f"Could not extract version from {value!r} "
+                f"(separator: {self.separator!r})"
+            )
         elif len(raw_parts) == 1:
             major = int(raw_parts[0])
             minor = 0


### PR DESCRIPTION
Follow-up of #308 and #317.

This applies the `pre-commit` formatting on the whole code-base

A few docstrings lines were exceeding the column limit but we're hardly breakable. I chose to put a `# noqa` directive so that black ignore them; but there might be a better solution (such as defining custom types and using them in the docstring if it makes sense).

A follow-up PR will add a `.git-blame-ignore-revs` file not to have the formatting disrupt `git blame` with some documentation to have it setup, see [scikit-learn's](https://github.com/scikit-learn/scikit-learn/blob/main/.git-blame-ignore-revs).