### PR TITLE
CI Add GitHub action to run pre-commit checks 

### DIFF
--- a/.github/workflows/run-code-format-checks.yaml
+++ b/.github/workflows/run-code-format-checks.yaml
@@ -1,0 +1,21 @@
+name: Run code format checks
+on:
+  pull_request:
+  push: { branches: main }
+
+jobs:
+  run-pre-commit-checks:
+    name: Run pre-commit checks
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install pre-commit setup
+      run: |
+        pip install pre-commit
+        pre-commit install
+
+    - name: Run checks
+      run: pre-commit run

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,6 @@ repos:
     hooks:
     -   id: flake8
         types: [file, python]
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
-    hooks:
-     -  id: mypy
-        files: dirty_cat/
 -   repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
Follow-up of #308.

This also remove mypy checks from pre-commit setup which creates confusion with version parsing via the private `Version` class.