### PR TITLE
DEV Ignore black code formating in `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,12 @@
+# Since git version 2.23, git-blame has a feature to ignore
+# certain commits.
+#
+# This file contains a list of commits that are not likely what
+# you are looking for in `git blame`. You can set this file as
+# a default ignore file for blame by running the following
+# command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# PR 314:  MAINT Format the code-base to be pre-commit compliant
+4c8e17882d602e4b314ce150ad345e59a88e2aab

--- a/README.rst
+++ b/README.rst
@@ -6,13 +6,16 @@ dirty_cat
    :alt: dirty_cat logo
 
 
-|py_ver| |pypi_var| |pypi_dl| |codecov| |circleci|
+|py_ver| |pypi_var| |pypi_dl| |codecov| |circleci| |Black|
 
 .. |py_ver| image:: https://img.shields.io/pypi/pyversions/dirty_cat
 .. |pypi_var| image:: https://img.shields.io/pypi/v/dirty_cat?color=informational
 .. |pypi_dl| image:: https://img.shields.io/pypi/dm/dirty_cat
 .. |codecov| image:: https://img.shields.io/codecov/c/github/dirty-cat/dirty_cat/master
 .. |circleci| image:: https://img.shields.io/circleci/build/github/dirty-cat/dirty_cat/master?label=CircleCI
+.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+   .. _Black: https://github.com/psf/black
+
 
 dirty_cat is a Python module for machine-learning on dirty categorical variables.
 


### PR DESCRIPTION
This comes as a follow-up of #314.

It adds a badge on the `README` to indicate that dirty_cat uses black.

It introduces .git-blame-ignore-revs, which contains a list of commits to be ignore via `git blame`. 

This file can be set as the default ignore file for blame by running the following command:

```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```