### PR TITLE
DOC fix repeated semicolon

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -327,6 +327,7 @@ dl.py.class dl.field-list {
     padding-bottom: .5em;
 }
 
+/* Avoid a double semicolon in the docstrings with latest sphinx */
 dl.field-list > dt:after {
     content: "";
   }

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -327,6 +327,10 @@ dl.py.class dl.field-list {
     padding-bottom: .5em;
 }
 
+dl.field-list > dt:after {
+    content: "";
+  }
+
 p.side-comment {
     font-size: smaller;
     text-align: right;


### PR DESCRIPTION
With the latest sphinx, there is an issue with repeated semicolons:

<img width="138" alt="image" src="https://user-images.githubusercontent.com/7454015/190105204-1d968f5e-e92a-4651-8df5-d9fd5a9b4d26.png">

This PR is solving this issue by editing the CSS file.