### PR TITLE
MAINT remove if __name__ == 'main'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,6 @@ exclude_lines =
     if self.debug:
     pragma: no cover
     raise NotImplementedError
-    if __name__ == .__main__.:
 ignore_errors = True
 omit =
     */test_*

--- a/dirty_cat/_fast_hash.py
+++ b/dirty_cat/_fast_hash.py
@@ -88,13 +88,3 @@ def ngram_min_hash(string, ngram_range=(2, 4), seed=0, return_minmax=False):
     if return_minmax:
         return min_hash, max_hash
     return min_hash
-
-
-if __name__ == "__main__":
-    # Download demo text
-    from sklearn import datasets
-
-    data = datasets.fetch_20newsgroups()
-    a = data.data[0]
-
-    h = ngram_min_hash(a)

--- a/dirty_cat/_test/test_fast_hash.py
+++ b/dirty_cat/_test/test_fast_hash.py
@@ -16,7 +16,3 @@ def test_fast_hash():
 
     min_hash4 = ngram_min_hash(a, seed=0, return_minmax=True)
     assert len(min_hash4) == 2
-
-
-if __name__ == "__main__":
-    test_fast_hash()

--- a/dirty_cat/_test/test_gap_encoder.py
+++ b/dirty_cat/_test/test_gap_encoder.py
@@ -200,35 +200,3 @@ def test_missing_values(missing: str) -> None:
             r"'error' or 'zero_impute', got 'aaa'",
         ):
             enc.fit_transform(observations)
-
-
-if __name__ == "__main__":
-    print("test_analyzer")
-    test_analyzer()
-    print("test_analyzer passed")
-
-    print("start test_gap_encoder")
-    test_gap_encoder(hashing=True, init="k-means++", analyzer="char", add_words=False)
-    print("passed")
-
-    print("start test_input_type")
-    test_input_type()
-    print("passed")
-
-    print("start test_partial_fit")
-    test_partial_fit()
-    print("passed")
-
-    print("start test_get_feature_names_out")
-    test_get_feature_names_out()
-    print("passed")
-
-    print("start test_overflow_error")
-    test_overflow_error()
-    print("passed")
-
-    print("start test_score")
-    test_score()
-    print("test_score passed")
-
-    print("Done")

--- a/dirty_cat/_test/test_minhash_encoder.py
+++ b/dirty_cat/_test/test_minhash_encoder.py
@@ -149,24 +149,15 @@ def test_cache_overflow() -> None:
     assert len(y[y == -1.0]) == 0
 
 
-if __name__ == "__main__":
-    print("start test_MinHashEncoder")
-    test_MinHashEncoder()
-    print("passed")
+@pytest.mark.parametrize("idx", range(3))
+def test_min_hash_encoder_hashing_fast_minmax_hash(idx):
+    print(f"{profile_encoder(hashing='fast', minmax_hash=True):.4} seconds")
 
-    print("start test_multiple_columns")
-    test_multiple_columns()
-    print("passed")
 
-    for _ in range(3):
-        print("time profile_encoder(MinHashEncoder, hashing=fast)")
-        print(f"{profile_encoder(hashing='fast'):.4} seconds")
+@pytest.mark.parametrize("idx", range(3))
+def test_min_hash_encoder_hashing_fast(idx):
+    print(f"{profile_encoder(hashing='fast'):.4} seconds")
 
-    for _ in range(3):
-        print("time profile_encoder(MinHashEncoder, hashing=fast) with minmax")
-        print(f"{profile_encoder(hashing='fast', minmax_hash=True):.4} seconds")
 
-    print("time profile_encoder(MinHashEncoder, hashing=murmur)")
+def test_min_hash_encoder_mumur():
     print(f"{profile_encoder(hashing='murmur'):.4} seconds")
-
-    print("Done")

--- a/dirty_cat/_test/test_super_vectorizer.py
+++ b/dirty_cat/_test/test_super_vectorizer.py
@@ -445,39 +445,3 @@ def test_passthrough():
     dirty_flat_trans_df = X_enc_dirty.to_numpy().ravel().tolist()
     assert all(map(_is_equal, zip(dirty_flat_df, dirty_flat_trans_df)))
     assert (X_clean.to_numpy() == X_enc_clean.to_numpy()).all()
-
-
-if __name__ == "__main__":
-    print("start test_super_vectorizer with clean df")
-    test_with_clean_data()
-    print("passed")
-
-    print("start test_super_vectorizer with dirty df")
-    test_with_dirty_data()
-    print("passed")
-
-    print("start test_auto_cast")
-    test_auto_cast()
-    print("passed")
-
-    print("start test_with_arrays")
-    test_with_arrays()
-    print("test_with_arrays passed")
-
-    print("start  test_get_feature_names_out")
-    test_get_feature_names_out()
-    print("passed")
-
-    print("start test_fit")
-    test_fit()
-    print("passed")
-
-    print("start fit_transform_equiv")
-    test_fit_transform_equiv()
-    print("passed")
-
-    print("start test_passthrough")
-    test_passthrough()
-    print("passed")
-
-    print("Done")

--- a/dirty_cat/datasets/_tests/test_fetching.py
+++ b/dirty_cat/datasets/_tests/test_fetching.py
@@ -383,10 +383,3 @@ def test_import_all_datasets(
 
         returned_value = _fetching.fetch_drug_directory()
         assert expected_return_value == returned_value
-
-
-if __name__ == "__main__":
-    print("Tests starting")
-    test_fetch_openml_dataset_mocked()
-    test_fetch_openml_dataset()
-    print("Tests passed")


### PR DESCRIPTION
closes #334 

Remove the `if __name__ == "main"` from the tests and module files since it is not required.
I let the one in the benchmark since they can be used with `python my_bench.py`.