### PR TITLE
Add warning banner on development documentation

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -48,6 +48,16 @@ div.body pre {
 
 }
 
+/* Banner for warning the user */
+.warn-banner {
+  background: pink;
+  border: 1px solid red;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  text-align: center;
+  margin-bottom: 1em;
+}
+
 /* For title page */
 
 div.flex-content {

--- a/doc/_templates/about.html
+++ b/doc/_templates/about.html
@@ -3,6 +3,14 @@
     https://github.com/bitprophet/alabaster/blob/master/alabaster/about.html
     Only the "Version" number is added.
 -->
+{% if "dev" in version %}
+<div class="warn-banner">
+    <p>
+        This is the documentation for the unstable development version.<br />
+        <a href="https://dirty-cat.github.io/stable/">Click here to go to the stable version documentation</a>.
+    </p>
+</div>
+{% endif %}
 {% if theme_logo %}
 <p class="logo">
   <a href="{{ pathto(master_doc) }}">

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,11 +18,12 @@
 #
 import os
 import shutil
+from datetime import datetime
 
 # -- Copy files for docs --------------------------------------------------
 #
 # We avoid duplicating the information, but we do not use symlinks to be
-# able to build the docs on windows
+# able to build the docs on Windows
 shutil.copyfile("../RELEASE_PROCESS.rst", "RELEASE_PROCESS.rst")
 shutil.copyfile("../CHANGES.rst", "CHANGES.rst")
 shutil.copyfile("../CONTRIBUTING.rst", "CONTRIBUTING.rst")
@@ -70,7 +71,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "dirty_cat"
-copyright = "2018-2021, dirty_cat developers"
+copyright = f"2018-{datetime.now().year}, the dirty_cat developers"
 author = "dirty_cat developers"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Fixes #361

Adds a warning banner in the "about" section, which is the left panel on the website page.
It has the advantage of being visible wherever you are on the website, and as it's the only big red thing on the screen, it's pretty noticeable, so that should do the trick.
Adding it to page RST (for example in `class.rst`) was a hustle, so I ended up dropping this idea.