### PR TITLE
Fix generated doc push to website

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: ls -ltrh doc/_build/html
       - deploy:
           command: |
-            if [[ "${CIRCLE_BRANCH}" =~ ^master$|^[0-9]+\.[0-9]+\.X$ ]]; then
+            if [[ "${CIRCLE_BRANCH}" =~ ^main$|^[0-9]+\.[0-9]+\.X$ ]]; then
               bash build_tools/circle/push_doc.sh doc/_build/html
             fi
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -49,8 +49,8 @@ get_build_type() {
         echo BUILD: not a pull request
         return
     fi
-    git_range="origin/master...$CIRCLE_SHA1"
-    git fetch origin master >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
+    git_range="origin/main...$CIRCLE_SHA1"
+    git fetch origin main >&2 || (echo QUICK BUILD: failed to get changed filenames for $git_range; return)
     filenames=$(git diff --name-only $git_range)
     if [ -z "$filenames" ]
     then
@@ -76,7 +76,7 @@ then
     exit 0
 fi
 
-if [[ "$CIRCLE_BRANCH" =~ ^master$|^[0-9]+\.[0-9]+\.X$ && -z "$CI_PULL_REQUEST" ]]
+if [[ "$CIRCLE_BRANCH" =~ ^main$|^[0-9]+\.[0-9]+\.X$ && -z "$CI_PULL_REQUEST" ]]
 then
     make_args="html"
 elif [[ "$build_type" =~ ^QUICK ]]
@@ -118,7 +118,7 @@ conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx \
   seaborn statsmodels pillow cython joblib pandas="${PANDAS_VERSION:-*}"
-#removed scikit learn from conda since it is installed from master after
+#removed scikit learn from conda since it is installed from main after
 
 source activate testenv
 pip install sphinx-gallery
@@ -130,7 +130,7 @@ pip install scikit-learn
 # Build and install the project in dev mode
 python setup.py develop
 
-#if [[ "$CIRCLE_BRANCH" =~ ^master$ && -z "$CI_PULL_REQUEST" ]]
+#if [[ "$CIRCLE_BRANCH" =~ ^main$ && -z "$CI_PULL_REQUEST" ]]
 #then
 #    # List available documentation versions if on default branch
 #    python build_tools/circle/list_versions.py > doc/versions.rst
@@ -143,7 +143,7 @@ cd -
 set +o pipefail
 
 affected_doc_paths() {
-    files=$(git diff --name-only origin/master...$CIRCLE_SHA1)
+    files=$(git diff --name-only origin/main...$CIRCLE_SHA1)
     echo "$files" | grep ^doc/.*\.rst | sed 's/^doc\/\(.*\)\.rst$/\1.html/'
     echo "$files" | grep ^examples/.*.py | sed 's/^\(.*\)\.py$/auto_\1.html/'
     project_files=$(echo "$files" | grep '^dirty_cat/')

--- a/build_tools/circle/push_doc.sh
+++ b/build_tools/circle/push_doc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script is meant to be called in the "deploy" step defined in 
+# This script is meant to be called in the "deploy" step defined in
 # circle.yml. See https://circleci.com/docs/ for more details.
 # The behavior of the script is controlled by environment variable defined
 # in the circle.yml in the top level folder of the project.
@@ -20,7 +20,7 @@ fi
 # Absolute path needed because we use cd further down in this script
 GENERATED_DOC_DIR=$(readlink -f $GENERATED_DOC_DIR)
 
-if [ "$CIRCLE_BRANCH" = "master" ]
+if [ "$CIRCLE_BRANCH" = "main" ]
 then
     dir=dev
 else
@@ -48,8 +48,8 @@ then
 	git add $dir
 fi
 
-git checkout master
-git reset --hard origin/master
+git checkout main
+git reset --hard origin/main
 if [ -d $dir ]
 then
 	git rm -rf $dir/ && rm -rf $dir/


### PR DESCRIPTION
Fixes #393.

As discussed over there, it seems some occurrences of `master` were not renamed and which causes the generated doc to not be pushed to the website repo.
I didn't because I wasn't sure what the environment variables were (e.g. `CIRCLE_BRANCH`). Should've checked :p
https://circleci.com/docs/built-in-environment-variables/