### PR TITLE
DOC Fix readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ dirty_cat can be easily installed via `pip`::
 Dependencies
 ~~~~~~~~~~~~
 
-Dependencies and minimal versions are listed in the file `min-requirements.txt <https://github.com/dirty-cat/dirty_cat/blob/main/requirements-min.txt>`_
+Dependencies and minimal versions are listed in the `setup <https://github.com/dirty-cat/dirty_cat/blob/main/setup.cfg#L26>`_ file.
 
 Related projects
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
 
 |py_ver| |pypi_var| |pypi_dl| |codecov| |circleci| |black|
 
-.. |py_ver| image:: https://img.shields.io/badge/python-3.6%20|%203.7%20|%203.8%20|%203.9%20|%203.10-blue
+.. |py_ver| image:: https://img.shields.io/pypi/pyversions/dirty_cat
 .. |pypi_var| image:: https://img.shields.io/pypi/v/dirty_cat?color=informational
 .. |pypi_dl| image:: https://img.shields.io/pypi/dm/dirty_cat
 .. |codecov| image:: https://img.shields.io/codecov/c/github/dirty-cat/dirty_cat/main


### PR DESCRIPTION
Small fix.

Spotted a missing link in the new version of the README 

This is because we deleted `min_requirements.txt` in the meantime.