### PR TITLE
DOC Replace get_feature_names by get_feature_names_out

### DIFF
--- a/dirty_cat/_similarity_encoder.py
+++ b/dirty_cat/_similarity_encoder.py
@@ -271,7 +271,7 @@ class SimilarityEncoder(OneHotEncoder):
     array([['Female', 1],
            ['Male', None]], dtype=object)
 
-    >>> enc.get_feature_names(['gender', 'group'])
+    >>> enc.get_feature_names_out(['gender', 'group'])
     array(['gender_Female', 'gender_Male', 'group_1', 'group_2', 'group_3'], ...)
 
     Attributes


### PR DESCRIPTION
Small fix. 
As `get_feature_names` will be deprecated, it's best to use directly `get_feature_names_out` in the small example.