### PR TITLE
Fix em dash in website titles

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,7 @@ import os
 import shutil
 from datetime import datetime
 import sys
+
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
@@ -174,7 +175,7 @@ html_static_path = ["_static"]
 
 
 # Modify the title to get good social-media links
-html_title = "&mdash; Dirty cat"
+html_title = "— Dirty cat"
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -177,6 +177,7 @@ html_static_path = ["_static"]
 # Modify the title to get good social-media links
 html_title = "— dirty_cat"
 
+
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,7 +175,7 @@ html_static_path = ["_static"]
 
 
 # Modify the title to get good social-media links
-html_title = "dirty_cat"
+html_title = "— dirty_cat"
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,7 +175,7 @@ html_static_path = ["_static"]
 
 
 # Modify the title to get good social-media links
-html_title = "— Dirty cat"
+html_title = "Dirty cat"
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -175,7 +175,7 @@ html_static_path = ["_static"]
 
 
 # Modify the title to get good social-media links
-html_title = "Dirty cat"
+html_title = "dirty_cat"
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
Currently, page titles are rendered with the code ``&mdash`` in the title, which is very ugly.
The dash is already rendered by sphinx or whatnot, so we should remove it.