### PR TITLE
BUG Remove unused get_features_name function in GapEncoder

### DIFF
--- a/dirty_cat/_gap_encoder.py
+++ b/dirty_cat/_gap_encoder.py
@@ -303,20 +303,6 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         self.H_dict_.update(zip(unq_X, unq_H))
         return self
 
-    def get_feature_names(self, n_labels=3, prefix=""):
-        """
-        Ensures compatibility with sklearn < 1.0.
-        Use `get_feature_names_out` instead.
-        """
-        warnings.warn(
-            "Following the changes in scikit-learn 1.0, "
-            "get_feature_names is deprecated. "
-            "Use get_feature_names_out instead. ",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.get_feature_names_out(n_labels=n_labels, prefix=prefix)
-
     def get_feature_names_out(
         self,
         n_labels: int = 3,


### PR DESCRIPTION
When working on #434, I realized there was an unused get_feature_names function in the GapEncoder that could be removed safely.