### PR TITLE
fix circleCI doc building

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -108,7 +108,7 @@ fi
 # Install dependencies with miniconda
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
    -O miniconda.sh
-chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
+chmod +x miniconda.sh && bash ./miniconda.sh -b -p $MINICONDA_PATH
 export PATH="$MINICONDA_PATH/bin:$PATH"
 conda update --yes --quiet conda
 

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -108,7 +108,7 @@ fi
 # Install dependencies with miniconda
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
    -O miniconda.sh
-chmod +x miniconda.sh && bash ./miniconda.sh -b -p $MINICONDA_PATH
+chmod +x miniconda.sh && ./miniconda.sh -b -p $MINICONDA_PATH
 export PATH="$MINICONDA_PATH/bin:$PATH"
 conda update --yes --quiet conda
 


### PR DESCRIPTION
Fix #447 

Using the fix from https://github.com/ContinuumIO/anaconda-issues/issues/13110 works. What I'm not sure is why it only appeared now.

Once this is merged, tests on failing PRs should be relaunched.