### PR TITLE
Replace np.array with np.ndarray in type hints

### DIFF
--- a/dirty_cat/_datetime_encoder.py
+++ b/dirty_cat/_datetime_encoder.py
@@ -186,7 +186,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X, y=None) -> np.array:
+    def transform(self, X, y=None) -> np.ndarray:
         """Transform X by replacing each datetime column with corresponding numerical features.
 
         Parameters
@@ -198,7 +198,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        np.array, shape (n_samples, n_features_out_)
+        np.ndarray, shape (n_samples, n_features_out_)
             Transformed input.
         """
         check_is_fitted(

--- a/dirty_cat/_gap_encoder.py
+++ b/dirty_cat/_gap_encoder.py
@@ -46,7 +46,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
     """See GapEncoder's docstring."""
 
     rho_: float
-    H_dict_: Dict[np.array, np.array]
+    H_dict_: Dict[np.ndarray, np.ndarray]
 
     def __init__(
         self,
@@ -88,7 +88,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         self.rescale_W = rescale_W
         self.max_iter_e_step = max_iter_e_step
 
-    def _init_vars(self, X) -> Tuple[np.array, np.array, np.array]:
+    def _init_vars(self, X) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Build the bag-of-n-grams representation V of X and initialize
         the topics W.

--- a/dirty_cat/_similarity_encoder.py
+++ b/dirty_cat/_similarity_encoder.py
@@ -33,12 +33,12 @@ from ._utils import parse_version
 
 
 def _ngram_similarity_one_sample_inplace(
-    x_count_vector: np.array,
-    vocabulary_count_matrix: np.array,
+    x_count_vector: np.ndarray,
+    vocabulary_count_matrix: np.ndarray,
     str_x: str,
-    vocabulary_ngram_counts: np.array,
+    vocabulary_ngram_counts: np.ndarray,
     se_dict: dict,
-    unq_X: np.array,
+    unq_X: np.ndarray,
     i: int,
     ngram_range: Tuple[int, int],
 ) -> None:
@@ -47,17 +47,17 @@ def _ngram_similarity_one_sample_inplace(
 
     Parameters
     ----------
-    x_count_vector : np.array
+    x_count_vector : np.ndarray
         Count vector of the sample based on the ngrams of the vocabulary
-    vocabulary_count_matrix : np.array
+    vocabulary_count_matrix : np.ndarray
         Count vector of the vocabulary based on its ngrams
     str_x: str
         The actual sample string
-    vocabulary_ngram_counts : np.array
+    vocabulary_ngram_counts : np.ndarray
         Number of ngrams for each unique element of the vocabulary
     se_dict : dict
         Dictionary containing the similarities for each x in unq_X
-    unq_X : np.array
+    unq_X : np.ndarray
         The arrays of all unique samples
     i : str
         The index of x_count_vector in the csr count matrix
@@ -86,7 +86,7 @@ def ngram_similarity(
     ngram_range: Tuple[int, int],
     hashing_dim: int,
     dtype: type = np.float64,
-) -> np.array:
+) -> np.ndarray:
     """
     Similarity encoding for dirty categorical variables:
     Given two arrays of strings, returns the similarity encoding matrix
@@ -139,7 +139,7 @@ def ngram_similarity(
     return np.nan_to_num(out, copy=False)
 
 
-def get_prototype_frequencies(prototypes: np.array) -> np.array:
+def get_prototype_frequencies(prototypes: np.ndarray) -> np.array:
     """
     Computes the frequencies of the values contained in prototypes
     Reverse sorts the array by the frequency

--- a/dirty_cat/_target_encoder.py
+++ b/dirty_cat/_target_encoder.py
@@ -55,7 +55,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
     ----------
     n_features_in_: int
         Number of features in the data seen during fit.
-    categories_ : typing.List[np.array]
+    categories_ : typing.List[np.ndarray]
         The categories of each feature determined during fitting
         (in order corresponding with output of ``transform``).
 
@@ -69,7 +69,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
     --------
     >>> enc = TargetEncoder(handle_unknown='ignore')
     >>> X = [['male'], ['Male'], ['Female'], ['male'], ['Female']]
-    >>> y = np.array([1, 2, 3, 4, 5])
+    >>> y = np.ndarray([1, 2, 3, 4, 5])
 
     >>> enc.fit(X, y)
     TargetEncoder(handle_unknown='ignore')
@@ -94,12 +94,12 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
 
     n_features_in_: int
     _label_encoders_: List[LabelEncoder]
-    categories_: List[np.array]
+    categories_: List[np.ndarray]
     n_: int
 
     def __init__(
         self,
-        categories: Union[Literal["auto"], List[Union[List[str], np.array]]] = "auto",
+        categories: Union[Literal["auto"], List[Union[List[str], np.ndarray]]] = "auto",
         clf_type: Literal["regression", "binary-clf", "multiclass-clf"] = "binary-clf",
         dtype: type = np.float64,
         handle_unknown: Literal["error", "ignore"] = "error",
@@ -211,7 +211,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         self.k_ = {j: len(self.counter_[j]) for j in self.counter_}
         return self
 
-    def transform(self, X) -> np.array:
+    def transform(self, X) -> np.ndarray:
         """
         Transform X using the specified encoding scheme.
 
@@ -222,7 +222,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        2-d np.array
+        2-d np.ndarray
             Transformed input.
         """
         check_is_fitted(self, attributes=["n_features_in_"])

--- a/dirty_cat/_utils.py
+++ b/dirty_cat/_utils.py
@@ -41,7 +41,7 @@ class LRUDict:
         return key in self.cache
 
 
-def check_input(X) -> np.array:
+def check_input(X) -> np.ndarray:
     """
     Check input with sklearn standards.
     Also converts X to a numpy array if not already.

--- a/dirty_cat/tests/test_super_vectorizer.py
+++ b/dirty_cat/tests/test_super_vectorizer.py
@@ -77,7 +77,7 @@ def _get_dirty_dataframe() -> pd.DataFrame:
     )
 
 
-def _get_numpy_array() -> np.array:
+def _get_numpy_array() -> np.ndarray:
     return np.array(
         [
             ["15", "56", pd.NA, "12", ""],


### PR DESCRIPTION
Small PR that replaces `np.array` with `np.ndarray` in type hints.
This is because `np.array` is a function and `np.ndarray` is the object.