### PR TITLE
More informative error when n_samples < n_components in GapEncoder

### DIFF
--- a/dirty_cat/_gap_encoder.py
+++ b/dirty_cat/_gap_encoder.py
@@ -777,6 +777,11 @@ class GapEncoder(BaseEstimator, TransformerMixin):
             Fitted :class:`~dirty_cat.GapEncoder` instance (self).
         """
 
+        # Check that n_samples >= n_components
+        if len(X) < self.n_components:
+            raise ValueError(
+                f"n_samples={len(X)} should be >= n_components={self.n_components}. "
+            )
         # Copy parameter rho
         self.rho_ = self.rho
         # If X is a dataframe, store its column names
@@ -875,7 +880,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
 
                 - if the input data was a dataframe, its column names are used,
                 - otherwise, 'col1', ..., 'colN' are used as prefixes.
-                
+
             Prefixes can be manually set by passing a list for col_names.
         n_labels : int, default=3
             The number of labels used to describe each topic.

--- a/dirty_cat/tests/test_gap_encoder.py
+++ b/dirty_cat/tests/test_gap_encoder.py
@@ -197,13 +197,22 @@ def test_missing_values(missing: str) -> None:
         ):
             enc.fit_transform(observations)
 
+
 def test_check_fitted_gap_encoder():
     """Test that calling transform before fit raises an error"""
     X = np.array([["alice"], ["bob"]])
     enc = GapEncoder(n_components=2, random_state=42)
     with pytest.raises(NotFittedError):
         enc.transform(X)
-    
+
     # Check that it works after fit
     enc.fit(X)
     enc.transform(X)
+
+
+def test_small_sample():
+    """Test that having n_samples < n_components raises an error"""
+    X = np.array([["alice"], ["bob"]])
+    enc = GapEncoder(n_components=3, random_state=42)
+    with pytest.raises(ValueError, match="should be >= n_components"):
+        enc.fit_transform(X)


### PR DESCRIPTION
Solves #474

Previously, an error was raised from Kmeans, and talked about `n_clusters` instead of `n_components`. 