### PR TITLE
DOC: css for narrow screens

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -133,8 +133,8 @@ div.install-instructions {
 /* Wide screens: use better the full width */
 @media only screen and (min-width: 1400px) {
     div.body section:first-of-type h1 {
-	width: 1080px;
-	left: -200px;
+	width: 980px;
+	left: -150px;
 	position: relative;
 	margin-top: 1ex;
 	margin-bottom: 2ex;
@@ -155,14 +155,25 @@ div.install-instructions {
     }
 
     div.larger-container {
-	width: 1080px;
-	left: -200px;
+	width: 880px;
+	left: -100px;
 	position: relative;
     }
-
 }
 
 @media only screen and (min-width: 1500px) {
+    div.body section:first-of-type h1 {
+	width: 1080px;
+	left: -200px;
+    }
+
+    div.larger-container {
+	width: 1080px;
+	left: -200px;
+    }
+}
+
+@media only screen and (min-width: 1600px) {
     div.body section:first-of-type h1 {
 	width: 1280px;
 	left: -300px;

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -72,12 +72,30 @@ div.flex-content p {
     margin-right: 1ex;
 }
 
+div.flex-content ul p {
+    margin-left: 0ex;
+}
+
+/* Override a alabaster behavior which does not work well on the front
+ * page */
+@media screen and (max-width: 870px)
+div.flex-content ul {
+  margin-left: 23px;
+}
+
 div.flex-content ul a span.std {
     float: right;
    }
 
 /* Avoid an overlap of the float with the line below, eg on narrow screens */
 div.flex-content ul li {
+    clear: both;
+}
+
+/* Make sure that floats don't extend out of the div */
+div.flex-content:after {
+    content: '';
+    display: block;
     clear: both;
 }
 

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -474,7 +474,7 @@ div.sphinxsidebarwrapper h1.logo-name {
     }
 }
 
-@media screen and (min-width: 1500px) {
+@media screen and (min-width: 1600px) {
     div.document div.sphinxsidebar {
 	left: 10%;
     }

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -78,9 +78,10 @@ div.flex-content ul p {
 
 /* Override a alabaster behavior which does not work well on the front
  * page */
-@media screen and (max-width: 870px)
-div.flex-content ul {
-  margin-left: 23px;
+@media screen and (max-width: 870px) {
+    div.flex-content ul {
+	margin-left: 23px;
+    }
 }
 
 div.flex-content ul a span.std {
@@ -93,7 +94,7 @@ div.flex-content ul li {
 }
 
 /* Make sure that floats don't extend out of the div */
-div.flex-content:after {
+div.flex-content::after {
     content: '';
     display: block;
     clear: both;

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -82,6 +82,10 @@ div.flex-content ul p {
     div.flex-content ul {
 	margin-left: 23px;
     }
+
+    div.flex-content {
+	margin: 3ex auto;
+    }
 }
 
 div.flex-content ul a span.std {

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -67,6 +67,13 @@ div.flex-content {
     border-radius: 1ex 1ex 0ex 0ex;
 }
 
+@media screen and (max-width: 1400px) {
+    div.flex-content {
+	margin: 3ex auto;
+    }
+}
+
+
 div.flex-content p {
     margin-left: 1ex;
     margin-right: 1ex;
@@ -81,10 +88,6 @@ div.flex-content ul p {
 @media screen and (max-width: 870px) {
     div.flex-content ul {
 	margin-left: 23px;
-    }
-
-    div.flex-content {
-	margin: 3ex auto;
     }
 }
 
@@ -153,7 +156,7 @@ div.install-instructions {
 
     div.larger-container {
 	width: 1080px;
-	left: -140px;
+	left: -200px;
 	position: relative;
     }
 


### PR DESCRIPTION
Better layout on mobile phones

Should avoid the dangling list on the left, and the dangling "example" on the bottom right
![image](https://user-images.githubusercontent.com/208217/215829108-eddc544f-dd62-47ed-9b21-905b58e00389.png)
