### PR TITLE
Fix CI issue

### DIFF
--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -109,7 +109,8 @@ fi
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
    -O miniconda.sh
 chmod +x miniconda.sh && bash ./miniconda.sh -b -p $MINICONDA_PATH
-export PATH="$MINICONDA_PATH/bin:$PATH"
+#export PATH="$MINICONDA_PATH/bin:$PATH"
+source ~/.bashrc
 conda update --yes --quiet conda
 
 # Configure the conda environment and put it in the path using the

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -108,9 +108,8 @@ fi
 # Install dependencies with miniconda
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
    -O miniconda.sh
-chmod +x miniconda.sh && bash ./miniconda.sh -b -p $MINICONDA_PATH
-#export PATH="$MINICONDA_PATH/bin:$PATH"
-source ~/.bashrc
+chmod +x miniconda.sh && bash ./miniconda.sh -b -p "miniconda"
+export PATH="miniconda/bin:$PATH"
 conda update --yes --quiet conda
 
 # Configure the conda environment and put it in the path using the


### PR DESCRIPTION
Fixes #490 

The error is due to the way the path is interpreted when executing `chmod +x miniconda.sh && bash ./miniconda.sh -b -p $MINICONDA_PATH`: `$MINICONDA_PATH` is `"~/miniconda"`, which should be resolved to `/home/circleci/miniconda`. Instead, it is resolved as `/home/circleci/~/miniconda`. The next line, `export PATH="$MINICONDA_PATH/bin:$PATH"`, interprets the tilde correctly, and thus tries to find `/home/circleci/miniconda`, which doesn't exist.

To solve that, I've hardcoded the directory name `miniconda`, which is created in the same directory as `miniconda.sh`.

Please let us know if there is any drawback with this approach!