### PR TITLE
Set default value to None for similarity in SimilarityEncoder

### DIFF
--- a/dirty_cat/_similarity_encoder.py
+++ b/dirty_cat/_similarity_encoder.py
@@ -311,7 +311,7 @@ class SimilarityEncoder(OneHotEncoder):
 
     def __init__(
         self,
-        similarity: str = "ngram",
+        similarity: str = None,
         ngram_range: Tuple[int, int] = (2, 4),
         categories: Union[
             Literal["auto", "k-means", "most_frequent"], List[List[str]]


### PR DESCRIPTION
When instantiating the `SimilarityEncoder`, it raises a warning by default, which is bad behavior.

```
>>> SimilarityEncoder()
UserWarning: The "similarity" argument is deprecated since dirty_cat 0.3, and will be removed in 0.5.The n-gram similarity is the only one currently supported.
```