### PR TITLE
Fix long CI install

### DIFF
--- a/build_tools/github/install.sh
+++ b/build_tools/github/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-pip install --progress-bar off --upgrade ".[$DEPS_VERSION]" --use-pep517
+pip install --progress-bar off --only-binary :all: --upgrade ".[$DEPS_VERSION]"

--- a/build_tools/github/install.sh
+++ b/build_tools/github/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -e
 
-pip install --progress-bar off --upgrade ".[$DEPS_VERSION]"
+pip install --progress-bar off --upgrade ".[$DEPS_VERSION]" --use-pep517

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,12 +62,12 @@ min-py38 =
     pandas==1.2.0
 min-py39 =
     scikit-learn==0.23.0
-    numpy==1.17.3
+    numpy==1.19.3
     scipy==1.6.0
     pandas==1.2.0
 min-py310 =
     scikit-learn==0.24.0
-    numpy==1.23.0
+    numpy==1.21.2
     scipy==1.8.0
     pandas==1.3.5
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,12 +61,12 @@ min-py38 =
     scipy==1.4.0
     pandas==1.2.0
 min-py39 =
-    scikit-learn==0.23.0
+    scikit-learn==0.24.0
     numpy==1.19.3
     scipy==1.6.0
     pandas==1.2.0
 min-py310 =
-    scikit-learn==0.24.0
+    scikit-learn==1.0.2
     numpy==1.21.2
     scipy==1.8.0
     pandas==1.3.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ min-py39 =
     pandas==1.2.0
 min-py310 =
     scikit-learn==1.0.2
-    numpy==1.21.2
+    numpy==1.21.3
     scipy==1.8.0
     pandas==1.3.5
 


### PR DESCRIPTION
On some versions specified in the CI matrix, the installation of dirty_cat takes more than 10 minutes, which is very annoying and consumes resources pointlessly.
![image](https://user-images.githubusercontent.com/33222654/219059660-b7f620e2-7dd8-413f-9592-15784b81e616.png)
This PR attempts to fix that.