### PR TITLE
BLD Depends on `numpy>=1.21.2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ include_package_data = True
 packages = find:
 install_requires =
     scikit-learn>=0.23.0
-    numpy>=1.17.3
+    numpy>=1.21.2
     scipy>=1.4.0
     pandas>=1.2.0
     requests
@@ -60,12 +60,12 @@ benchmarks =
 # as defined in testing.yml.
 min-py38 =
     scikit-learn==0.23.0
-    numpy==1.17.3
+    numpy==1.21.2
     scipy==1.4.0
     pandas==1.2.0
 min-py39 =
     scikit-learn==0.23.0
-    numpy==1.17.3
+    numpy==1.21.2
     scipy==1.6.0
     pandas==1.2.0
 min-py310 =


### PR DESCRIPTION
On some configuration of the CI's matrix, jobs fail because NumPy can't be resolved. For instance see [this CI job log](https://github.com/dirty-cat/dirty_cat/actions/runs/4203720976/jobs/7293478495#step:4:32). This is due to conflicting versions of NumPy, which now needs to be at least 1.21.2.

This proposes making dirty_cat depends on numpy>=1.21.2.