### PR TITLE
FIX Do not densify sparse matrices in `fuzzy_join`

### DIFF
--- a/dirty_cat/_fuzzy_join.py
+++ b/dirty_cat/_fuzzy_join.py
@@ -247,7 +247,7 @@ def fuzzy_join(
     neigh = NearestNeighbors(n_neighbors=1)
 
     neigh.fit(aux_enc)
-    distance, neighbors = neigh.kneighbors(main_enc.toarray(), return_distance=True)
+    distance, neighbors = neigh.kneighbors(main_enc, return_distance=True)
     idx_closest = np.ravel(neighbors)
 
     main_table["fj_idx"] = idx_closest


### PR DESCRIPTION
Should fix https://github.com/dirty-cat/dirty_cat/issues/511.

Sparse matrices are supported by `sklearn.NearestNeighbors.kneighbors`.

@jovan-stojanovic: I guess one needs to add a non-regression test for this case. How does one proceed in `dirty_cat`?