### PR TITLE
DOC `FeatureAugmenter` typo quick fix

### DIFF
--- a/dirty_cat/_feature_augmenter.py
+++ b/dirty_cat/_feature_augmenter.py
@@ -29,7 +29,7 @@ class FeatureAugmenter(BaseEstimator, TransformerMixin):
     ----------
     tables : list of 2-tuples of (:class:`~pandas.DataFrame`, str)
         List of (table, column name) tuples
-        specyfying the transformer objects to be applied.
+        specifying the transformer objects to be applied.
         table: str
             Name of the table to be joined.
         column: str


### PR DESCRIPTION
**What does this implement/fix?**

Not all typo requires PRs, but since this one is easy to spot and is located on the first parameter of `FeatureAugmenter`, I thought it was necessary :)