### PR TITLE
DOC Configure filename_pattern to run all examples during doc build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -273,6 +273,7 @@ sphinx_gallery_conf = {
         # We don't specify the other modules as we use the intershpinx ext.
         # See https://sphinx-gallery.github.io/stable/configuration.html#link-to-documentation  # noqa
     },
+    "filename_pattern": ".*",
     "examples_dirs": "../examples",
     "gallery_dirs": "auto_examples",
     "within_subsection_order": FileNameSortKey,


### PR DESCRIPTION
Fix #527

Since #507 `"filename_pattern": ""` was removed so this reverted to the default sphinx-gallery behaviour which is to run the examples starting with `plot_`. I used `".*"` to match any kind of files which is a bit more explicit than `""`, you could also use `\d+_.*\.py` or a variation of it if you prefer.

Locally this work, but I am going to push a commit with `[doc build]` to make sure that examples are indeed run.
