### PR TITLE
Fix _set_drop_idx bug for sklearn versions >=1.2.0 and < 1.2.2

### DIFF
--- a/dirty_cat/_similarity_encoder.py
+++ b/dirty_cat/_similarity_encoder.py
@@ -521,7 +521,7 @@ class SimilarityEncoder(OneHotEncoder):
 
         if parse_version(sklearn.__version__) >= parse_version("1.1.0"):
             self._infrequent_enabled = False
-        if parse_version(sklearn.__version__) >= parse_version("1.2.0"):
+        if parse_version(sklearn.__version__) >= parse_version("1.2.2"):
             self.drop_idx_ = self._set_drop_idx()
         else:
             self.drop_idx_ = self._compute_drop_idx()


### PR DESCRIPTION
In sklearn's `OneHotEncoder`, `_compute_drop_idx()` was replaced by `_set_drop_idx()` in V1.2.2 (see https://github.com/scikit-learn/scikit-learn/commit/1380e3c09b46568cd536ebc6f4720388f2f763d5), but we use it from V1.2.0, causing a bug on sklearn's versions 1.2.0 and 1.2.1. This PR fixes this.